### PR TITLE
feat: location module - multi-location/franchise management

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/location/LocationApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/LocationApi.kt
@@ -1,3 +1,21 @@
 package com.nickdferrara.fitify.location
 
-interface LocationApi
+import com.nickdferrara.fitify.shared.DomainError
+import com.nickdferrara.fitify.shared.Result
+import java.util.UUID
+
+data class LocationSummary(
+    val id: UUID,
+    val name: String,
+    val address: String,
+    val city: String,
+    val state: String,
+    val zipCode: String,
+    val timeZone: String,
+    val active: Boolean,
+)
+
+interface LocationApi {
+    fun findLocationById(id: UUID): Result<LocationSummary, DomainError>
+    fun findAllActiveLocations(): List<LocationSummary>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/location/LocationEvents.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/LocationEvents.kt
@@ -1,0 +1,21 @@
+package com.nickdferrara.fitify.location
+
+import java.time.Instant
+import java.util.UUID
+
+data class LocationCreatedEvent(
+    val locationId: UUID,
+    val name: String,
+    val address: String,
+    val timeZone: String,
+)
+
+data class LocationUpdatedEvent(
+    val locationId: UUID,
+    val updatedFields: Set<String>,
+)
+
+data class LocationDeactivatedEvent(
+    val locationId: UUID,
+    val effectiveDate: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/AdminLocationController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/AdminLocationController.kt
@@ -1,0 +1,50 @@
+package com.nickdferrara.fitify.location.internal
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/admin/locations")
+internal class AdminLocationController(
+    private val locationService: LocationService,
+) {
+
+    @PostMapping
+    fun createLocation(@RequestBody request: CreateLocationRequest): ResponseEntity<LocationResponse> {
+        val response = locationService.createLocation(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping
+    fun listLocations(): ResponseEntity<List<LocationResponse>> {
+        return ResponseEntity.ok(locationService.findAll())
+    }
+
+    @GetMapping("/{locationId}")
+    fun getLocation(@PathVariable locationId: UUID): ResponseEntity<LocationResponse> {
+        return ResponseEntity.ok(locationService.findById(locationId))
+    }
+
+    @PutMapping("/{locationId}")
+    fun updateLocation(
+        @PathVariable locationId: UUID,
+        @RequestBody request: UpdateLocationRequest,
+    ): ResponseEntity<LocationResponse> {
+        return ResponseEntity.ok(locationService.updateLocation(locationId, request))
+    }
+
+    @DeleteMapping("/{locationId}")
+    fun deactivateLocation(@PathVariable locationId: UUID): ResponseEntity<Void> {
+        locationService.deactivateLocation(locationId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/Location.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/Location.kt
@@ -1,0 +1,49 @@
+package com.nickdferrara.fitify.location.internal
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "locations")
+internal class Location(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    var name: String,
+
+    var address: String,
+
+    var city: String,
+
+    var state: String,
+
+    @Column(name = "zip_code")
+    var zipCode: String,
+
+    var phone: String,
+
+    var email: String,
+
+    @Column(name = "time_zone")
+    var timeZone: String,
+
+    var active: Boolean = true,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+
+    @OneToMany(mappedBy = "location", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val operatingHours: MutableList<LocationOperatingHours> = mutableListOf(),
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationController.kt
@@ -1,0 +1,18 @@
+package com.nickdferrara.fitify.location.internal
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/locations")
+internal class LocationController(
+    private val locationService: LocationService,
+) {
+
+    @GetMapping
+    fun listActiveLocations(): ResponseEntity<List<LocationResponse>> {
+        return ResponseEntity.ok(locationService.findAllActive())
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationDtos.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationDtos.kt
@@ -1,0 +1,80 @@
+package com.nickdferrara.fitify.location.internal
+
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalTime
+import java.util.UUID
+
+internal data class CreateLocationRequest(
+    val name: String,
+    val address: String,
+    val city: String,
+    val state: String,
+    val zipCode: String,
+    val phone: String,
+    val email: String,
+    val timeZone: String,
+    val operatingHours: List<OperatingHoursRequest> = emptyList(),
+)
+
+internal data class UpdateLocationRequest(
+    val name: String? = null,
+    val address: String? = null,
+    val city: String? = null,
+    val state: String? = null,
+    val zipCode: String? = null,
+    val phone: String? = null,
+    val email: String? = null,
+    val timeZone: String? = null,
+    val operatingHours: List<OperatingHoursRequest>? = null,
+)
+
+internal data class OperatingHoursRequest(
+    val dayOfWeek: DayOfWeek,
+    val openTime: LocalTime,
+    val closeTime: LocalTime,
+)
+
+internal data class LocationResponse(
+    val id: UUID,
+    val name: String,
+    val address: String,
+    val city: String,
+    val state: String,
+    val zipCode: String,
+    val phone: String,
+    val email: String,
+    val timeZone: String,
+    val active: Boolean,
+    val createdAt: Instant,
+    val operatingHours: List<OperatingHoursResponse>,
+)
+
+internal data class OperatingHoursResponse(
+    val id: UUID,
+    val dayOfWeek: DayOfWeek,
+    val openTime: LocalTime,
+    val closeTime: LocalTime,
+)
+
+internal fun Location.toResponse() = LocationResponse(
+    id = id!!,
+    name = name,
+    address = address,
+    city = city,
+    state = state,
+    zipCode = zipCode,
+    phone = phone,
+    email = email,
+    timeZone = timeZone,
+    active = active,
+    createdAt = createdAt!!,
+    operatingHours = operatingHours.map { it.toResponse() },
+)
+
+internal fun LocationOperatingHours.toResponse() = OperatingHoursResponse(
+    id = id!!,
+    dayOfWeek = dayOfWeek,
+    openTime = openTime,
+    closeTime = closeTime,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationExceptionHandler.kt
@@ -1,0 +1,18 @@
+package com.nickdferrara.fitify.location.internal
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(assignableTypes = [AdminLocationController::class, LocationController::class])
+internal class LocationExceptionHandler {
+
+    @ExceptionHandler(LocationNotFoundException::class)
+    fun handleNotFound(ex: LocationNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Location not found"))
+    }
+}
+
+internal data class ErrorResponse(val message: String)

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationOperatingHours.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationOperatingHours.kt
@@ -1,0 +1,39 @@
+package com.nickdferrara.fitify.location.internal
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.util.UUID
+
+@Entity
+@Table(name = "location_operating_hours")
+internal class LocationOperatingHours(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    var location: Location? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    var dayOfWeek: DayOfWeek,
+
+    @Column(name = "open_time", nullable = false)
+    var openTime: LocalTime,
+
+    @Column(name = "close_time", nullable = false)
+    var closeTime: LocalTime,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationRepository.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.location.internal
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface LocationRepository : JpaRepository<Location, UUID> {
+    fun findByActiveTrue(): List<Location>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/LocationService.kt
@@ -1,7 +1,159 @@
 package com.nickdferrara.fitify.location.internal
 
 import com.nickdferrara.fitify.location.LocationApi
+import com.nickdferrara.fitify.location.LocationCreatedEvent
+import com.nickdferrara.fitify.location.LocationDeactivatedEvent
+import com.nickdferrara.fitify.location.LocationSummary
+import com.nickdferrara.fitify.location.LocationUpdatedEvent
+import com.nickdferrara.fitify.shared.DomainError
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
 
 @Service
-internal class LocationService : LocationApi
+internal class LocationService(
+    private val locationRepository: LocationRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+) : LocationApi {
+
+    override fun findLocationById(id: UUID): Result<LocationSummary, DomainError> {
+        val location = locationRepository.findById(id).orElse(null)
+            ?: return Result.Failure(NotFoundError("Location not found: $id"))
+        return Result.Success(location.toSummary())
+    }
+
+    override fun findAllActiveLocations(): List<LocationSummary> {
+        return locationRepository.findByActiveTrue().map { it.toSummary() }
+    }
+
+    fun findAll(): List<LocationResponse> {
+        return locationRepository.findAll().map { it.toResponse() }
+    }
+
+    fun findAllActive(): List<LocationResponse> {
+        return locationRepository.findByActiveTrue().map { it.toResponse() }
+    }
+
+    fun findById(id: UUID): LocationResponse {
+        val location = locationRepository.findById(id)
+            .orElseThrow { LocationNotFoundException(id) }
+        return location.toResponse()
+    }
+
+    @Transactional
+    fun createLocation(request: CreateLocationRequest): LocationResponse {
+        val location = Location(
+            name = request.name,
+            address = request.address,
+            city = request.city,
+            state = request.state,
+            zipCode = request.zipCode,
+            phone = request.phone,
+            email = request.email,
+            timeZone = request.timeZone,
+        )
+
+        request.operatingHours.forEach { hours ->
+            location.operatingHours.add(
+                LocationOperatingHours(
+                    location = location,
+                    dayOfWeek = hours.dayOfWeek,
+                    openTime = hours.openTime,
+                    closeTime = hours.closeTime,
+                )
+            )
+        }
+
+        val saved = locationRepository.save(location)
+
+        eventPublisher.publishEvent(
+            LocationCreatedEvent(
+                locationId = saved.id!!,
+                name = saved.name,
+                address = saved.address,
+                timeZone = saved.timeZone,
+            )
+        )
+
+        return saved.toResponse()
+    }
+
+    @Transactional
+    fun updateLocation(id: UUID, request: UpdateLocationRequest): LocationResponse {
+        val location = locationRepository.findById(id)
+            .orElseThrow { LocationNotFoundException(id) }
+
+        val updatedFields = mutableSetOf<String>()
+
+        request.name?.let { location.name = it; updatedFields.add("name") }
+        request.address?.let { location.address = it; updatedFields.add("address") }
+        request.city?.let { location.city = it; updatedFields.add("city") }
+        request.state?.let { location.state = it; updatedFields.add("state") }
+        request.zipCode?.let { location.zipCode = it; updatedFields.add("zipCode") }
+        request.phone?.let { location.phone = it; updatedFields.add("phone") }
+        request.email?.let { location.email = it; updatedFields.add("email") }
+        request.timeZone?.let { location.timeZone = it; updatedFields.add("timeZone") }
+
+        request.operatingHours?.let { hoursList ->
+            location.operatingHours.clear()
+            hoursList.forEach { hours ->
+                location.operatingHours.add(
+                    LocationOperatingHours(
+                        location = location,
+                        dayOfWeek = hours.dayOfWeek,
+                        openTime = hours.openTime,
+                        closeTime = hours.closeTime,
+                    )
+                )
+            }
+            updatedFields.add("operatingHours")
+        }
+
+        val saved = locationRepository.save(location)
+
+        if (updatedFields.isNotEmpty()) {
+            eventPublisher.publishEvent(
+                LocationUpdatedEvent(
+                    locationId = saved.id!!,
+                    updatedFields = updatedFields,
+                )
+            )
+        }
+
+        return saved.toResponse()
+    }
+
+    @Transactional
+    fun deactivateLocation(id: UUID) {
+        val location = locationRepository.findById(id)
+            .orElseThrow { LocationNotFoundException(id) }
+
+        location.active = false
+        locationRepository.save(location)
+
+        eventPublisher.publishEvent(
+            LocationDeactivatedEvent(
+                locationId = location.id!!,
+                effectiveDate = Instant.now(),
+            )
+        )
+    }
+
+    private fun Location.toSummary() = LocationSummary(
+        id = id!!,
+        name = name,
+        address = address,
+        city = city,
+        state = state,
+        zipCode = zipCode,
+        timeZone = timeZone,
+        active = active,
+    )
+}
+
+internal class LocationNotFoundException(id: UUID) :
+    RuntimeException("Location not found: $id")

--- a/src/test/kotlin/com/nickdferrara/fitify/location/internal/LocationServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/location/internal/LocationServiceTest.kt
@@ -1,0 +1,283 @@
+package com.nickdferrara.fitify.location.internal
+
+import com.nickdferrara.fitify.location.LocationCreatedEvent
+import com.nickdferrara.fitify.location.LocationDeactivatedEvent
+import com.nickdferrara.fitify.location.LocationUpdatedEvent
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalTime
+import java.util.Optional
+import java.util.UUID
+
+class LocationServiceTest {
+
+    private val locationRepository = mockk<LocationRepository>()
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    private val locationService = LocationService(locationRepository, eventPublisher)
+
+    private fun buildLocation(
+        id: UUID = UUID.randomUUID(),
+        name: String = "Downtown Gym",
+        active: Boolean = true,
+    ) = Location(
+        id = id,
+        name = name,
+        address = "123 Main St",
+        city = "New York",
+        state = "NY",
+        zipCode = "10001",
+        phone = "555-0100",
+        email = "downtown@fitify.com",
+        timeZone = "America/New_York",
+        active = active,
+        createdAt = Instant.now(),
+    )
+
+    @Test
+    fun `findLocationById returns summary when location exists`() {
+        val id = UUID.randomUUID()
+        val location = buildLocation(id = id)
+        every { locationRepository.findById(id) } returns Optional.of(location)
+
+        val result = locationService.findLocationById(id)
+
+        assertTrue(result is Result.Success)
+        val summary = (result as Result.Success).value
+        assertEquals(id, summary.id)
+        assertEquals("Downtown Gym", summary.name)
+        assertEquals("America/New_York", summary.timeZone)
+    }
+
+    @Test
+    fun `findLocationById returns failure when location does not exist`() {
+        val id = UUID.randomUUID()
+        every { locationRepository.findById(id) } returns Optional.empty()
+
+        val result = locationService.findLocationById(id)
+
+        assertTrue(result is Result.Failure)
+        val error = (result as Result.Failure).error
+        assertTrue(error is NotFoundError)
+    }
+
+    @Test
+    fun `findAllActiveLocations returns only active locations`() {
+        val active = buildLocation(name = "Active Gym", active = true)
+        every { locationRepository.findByActiveTrue() } returns listOf(active)
+
+        val results = locationService.findAllActiveLocations()
+
+        assertEquals(1, results.size)
+        assertEquals("Active Gym", results[0].name)
+    }
+
+    @Test
+    fun `createLocation persists and publishes event`() {
+        val request = CreateLocationRequest(
+            name = "Uptown Gym",
+            address = "456 Elm St",
+            city = "New York",
+            state = "NY",
+            zipCode = "10002",
+            phone = "555-0200",
+            email = "uptown@fitify.com",
+            timeZone = "America/New_York",
+            operatingHours = listOf(
+                OperatingHoursRequest(
+                    dayOfWeek = DayOfWeek.MONDAY,
+                    openTime = LocalTime.of(6, 0),
+                    closeTime = LocalTime.of(22, 0),
+                )
+            ),
+        )
+
+        val savedId = UUID.randomUUID()
+        every { locationRepository.save(any()) } answers {
+            val loc = firstArg<Location>()
+            Location(
+                id = savedId,
+                name = loc.name,
+                address = loc.address,
+                city = loc.city,
+                state = loc.state,
+                zipCode = loc.zipCode,
+                phone = loc.phone,
+                email = loc.email,
+                timeZone = loc.timeZone,
+                active = loc.active,
+                createdAt = Instant.now(),
+            ).also { saved ->
+                loc.operatingHours.forEach { hours ->
+                    saved.operatingHours.add(
+                        LocationOperatingHours(
+                            id = UUID.randomUUID(),
+                            location = saved,
+                            dayOfWeek = hours.dayOfWeek,
+                            openTime = hours.openTime,
+                            closeTime = hours.closeTime,
+                        )
+                    )
+                }
+            }
+        }
+
+        val response = locationService.createLocation(request)
+
+        assertEquals(savedId, response.id)
+        assertEquals("Uptown Gym", response.name)
+        assertEquals(1, response.operatingHours.size)
+        assertEquals(DayOfWeek.MONDAY, response.operatingHours[0].dayOfWeek)
+
+        val eventSlot = slot<LocationCreatedEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(savedId, eventSlot.captured.locationId)
+        assertEquals("Uptown Gym", eventSlot.captured.name)
+    }
+
+    @Test
+    fun `updateLocation updates fields and publishes event`() {
+        val id = UUID.randomUUID()
+        val existing = buildLocation(id = id, name = "Old Name")
+        every { locationRepository.findById(id) } returns Optional.of(existing)
+        every { locationRepository.save(any()) } answers { firstArg() }
+
+        val request = UpdateLocationRequest(name = "New Name", phone = "555-9999")
+
+        val response = locationService.updateLocation(id, request)
+
+        assertEquals("New Name", response.name)
+        assertEquals("555-9999", response.phone)
+        assertEquals("123 Main St", response.address) // unchanged
+
+        val eventSlot = slot<LocationUpdatedEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(setOf("name", "phone"), eventSlot.captured.updatedFields)
+    }
+
+    @Test
+    fun `updateLocation with no changes does not publish event`() {
+        val id = UUID.randomUUID()
+        val existing = buildLocation(id = id)
+        every { locationRepository.findById(id) } returns Optional.of(existing)
+        every { locationRepository.save(any()) } answers { firstArg() }
+
+        val request = UpdateLocationRequest() // all null
+
+        locationService.updateLocation(id, request)
+
+        verify(exactly = 0) { eventPublisher.publishEvent(any<LocationUpdatedEvent>()) }
+    }
+
+    @Test
+    fun `updateLocation throws when location not found`() {
+        val id = UUID.randomUUID()
+        every { locationRepository.findById(id) } returns Optional.empty()
+
+        assertThrows<LocationNotFoundException> {
+            locationService.updateLocation(id, UpdateLocationRequest(name = "X"))
+        }
+    }
+
+    @Test
+    fun `deactivateLocation sets active false and publishes event`() {
+        val id = UUID.randomUUID()
+        val existing = buildLocation(id = id, active = true)
+        every { locationRepository.findById(id) } returns Optional.of(existing)
+        every { locationRepository.save(any()) } answers { firstArg() }
+
+        locationService.deactivateLocation(id)
+
+        assertFalse(existing.active)
+
+        val eventSlot = slot<LocationDeactivatedEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(id, eventSlot.captured.locationId)
+        assertNotNull(eventSlot.captured.effectiveDate)
+    }
+
+    @Test
+    fun `deactivateLocation throws when location not found`() {
+        val id = UUID.randomUUID()
+        every { locationRepository.findById(id) } returns Optional.empty()
+
+        assertThrows<LocationNotFoundException> {
+            locationService.deactivateLocation(id)
+        }
+    }
+
+    @Test
+    fun `findById throws when location not found`() {
+        val id = UUID.randomUUID()
+        every { locationRepository.findById(id) } returns Optional.empty()
+
+        assertThrows<LocationNotFoundException> {
+            locationService.findById(id)
+        }
+    }
+
+    @Test
+    fun `updateLocation replaces operating hours when provided`() {
+        val id = UUID.randomUUID()
+        val existing = buildLocation(id = id)
+        existing.operatingHours.add(
+            LocationOperatingHours(
+                id = UUID.randomUUID(),
+                location = existing,
+                dayOfWeek = DayOfWeek.MONDAY,
+                openTime = LocalTime.of(6, 0),
+                closeTime = LocalTime.of(22, 0),
+            )
+        )
+        every { locationRepository.findById(id) } returns Optional.of(existing)
+        every { locationRepository.save(any()) } answers {
+            val loc = firstArg<Location>()
+            // Simulate JPA assigning IDs to new operating hours
+            loc.operatingHours.forEachIndexed { index, hours ->
+                if (hours.id == null) {
+                    loc.operatingHours[index] = LocationOperatingHours(
+                        id = UUID.randomUUID(),
+                        location = hours.location,
+                        dayOfWeek = hours.dayOfWeek,
+                        openTime = hours.openTime,
+                        closeTime = hours.closeTime,
+                    )
+                }
+            }
+            loc
+        }
+
+        val request = UpdateLocationRequest(
+            operatingHours = listOf(
+                OperatingHoursRequest(
+                    dayOfWeek = DayOfWeek.TUESDAY,
+                    openTime = LocalTime.of(7, 0),
+                    closeTime = LocalTime.of(21, 0),
+                ),
+                OperatingHoursRequest(
+                    dayOfWeek = DayOfWeek.WEDNESDAY,
+                    openTime = LocalTime.of(7, 0),
+                    closeTime = LocalTime.of(21, 0),
+                ),
+            )
+        )
+
+        val response = locationService.updateLocation(id, request)
+
+        assertEquals(2, response.operatingHours.size)
+        assertEquals(DayOfWeek.TUESDAY, response.operatingHours[0].dayOfWeek)
+        assertEquals(DayOfWeek.WEDNESDAY, response.operatingHours[1].dayOfWeek)
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #2: Location module for managing multiple gym/franchise locations. Locations are a foundational entity referenced by classes, coaches, business rules, and metrics.

- **JPA Entities**: `Location` and `LocationOperatingHours` with `locations` / `location_operating_hours` tables (UUID PKs, soft-delete via `active` flag, `@CreationTimestamp`)
- **Public API**: `LocationApi` interface with `LocationSummary` for cross-module consumption; `LocationCreatedEvent`, `LocationUpdatedEvent`, `LocationDeactivatedEvent` for Spring Modulith event-driven communication
- **Service Layer**: Full CRUD with partial update support (nullable fields in `UpdateLocationRequest`), operating hours replacement, and event publishing via `ApplicationEventPublisher`
- **REST Controllers**: Admin CRUD at `POST/GET/PUT/DELETE /api/v1/admin/locations` and authenticated user browsing at `GET /api/v1/locations`
- **Unit Tests**: 10 tests covering create, update (partial + operating hours replacement), deactivate, find, not-found error cases, and event publishing verification

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/v1/admin/locations` | Create a new location |
| `GET` | `/api/v1/admin/locations` | List all locations |
| `GET` | `/api/v1/admin/locations/{locationId}` | Get location details |
| `PUT` | `/api/v1/admin/locations/{locationId}` | Update a location |
| `DELETE` | `/api/v1/admin/locations/{locationId}` | Deactivate (soft-delete) |
| `GET` | `/api/v1/locations` | Browse active locations |

## Test plan

- [x] All 26 existing + new tests pass (`./gradlew test`)
- [x] Kotlin compilation succeeds
- [x] Spring Modulith structure verification passes
- [x] Manual API testing with Postman/curl against local Docker environment
- [x] Verify JPA schema generation against PostgreSQL

Closes https://github.com/nickdferrara/server-springboot-fitify/issues/2