### PR TITLE
feat: implement scheduling module

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/BookingCancelledEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/BookingCancelledEvent.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.scheduling
+
+import java.time.Instant
+import java.util.UUID
+
+data class BookingCancelledEvent(
+    val userId: UUID,
+    val classId: UUID,
+    val cancelledAt: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/ClassBookedEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/ClassBookedEvent.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.scheduling
+
+import java.time.Instant
+import java.util.UUID
+
+data class ClassBookedEvent(
+    val userId: UUID,
+    val classId: UUID,
+    val className: String,
+    val startTime: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/ClassFullEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/ClassFullEvent.kt
@@ -1,0 +1,9 @@
+package com.nickdferrara.fitify.scheduling
+
+import java.util.UUID
+
+data class ClassFullEvent(
+    val classId: UUID,
+    val className: String,
+    val waitlistSize: Int,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/SchedulingApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/SchedulingApi.kt
@@ -1,3 +1,21 @@
 package com.nickdferrara.fitify.scheduling
 
-interface SchedulingApi
+import com.nickdferrara.fitify.shared.DomainError
+import com.nickdferrara.fitify.shared.Result
+import java.time.Instant
+import java.util.UUID
+
+data class ClassSummary(
+    val id: UUID,
+    val name: String,
+    val classType: String,
+    val startTime: Instant,
+    val endTime: Instant,
+    val locationId: UUID,
+    val coachId: UUID,
+)
+
+interface SchedulingApi {
+    fun findClassById(id: UUID): Result<ClassSummary, DomainError>
+    fun findUpcomingClassesByLocationId(locationId: UUID): List<ClassSummary>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/WaitlistPromotedEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/WaitlistPromotedEvent.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.scheduling
+
+import java.time.Instant
+import java.util.UUID
+
+data class WaitlistPromotedEvent(
+    val userId: UUID,
+    val classId: UUID,
+    val className: String,
+    val startTime: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingService.kt
@@ -1,7 +1,0 @@
-package com.nickdferrara.fitify.scheduling.internal
-
-import com.nickdferrara.fitify.scheduling.SchedulingApi
-import org.springframework.stereotype.Service
-
-@Service
-internal class SchedulingService : SchedulingApi

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/advices/SchedulingExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/advices/SchedulingExceptionHandler.kt
@@ -1,0 +1,90 @@
+package com.nickdferrara.fitify.scheduling.internal.advices
+
+import com.nickdferrara.fitify.scheduling.internal.controller.AdminClassController
+import com.nickdferrara.fitify.scheduling.internal.controller.ClassController
+import com.nickdferrara.fitify.scheduling.internal.controller.WaitlistController
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ErrorResponse
+import com.nickdferrara.fitify.scheduling.internal.service.AlreadyBookedException
+import com.nickdferrara.fitify.scheduling.internal.service.BookingNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.CancellationWindowClosedException
+import com.nickdferrara.fitify.scheduling.internal.service.ClassNotBookableException
+import com.nickdferrara.fitify.scheduling.internal.service.DailyBookingLimitExceededException
+import com.nickdferrara.fitify.scheduling.internal.service.FitnessClassNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.ScheduleConflictException
+import com.nickdferrara.fitify.scheduling.internal.service.WaitlistEntryNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.WaitlistFullException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(
+    assignableTypes = [
+        AdminClassController::class,
+        ClassController::class,
+        WaitlistController::class,
+    ]
+)
+internal class SchedulingExceptionHandler {
+
+    @ExceptionHandler(FitnessClassNotFoundException::class)
+    fun handleClassNotFound(ex: FitnessClassNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Fitness class not found"))
+    }
+
+    @ExceptionHandler(BookingNotFoundException::class)
+    fun handleBookingNotFound(ex: BookingNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Booking not found"))
+    }
+
+    @ExceptionHandler(WaitlistEntryNotFoundException::class)
+    fun handleWaitlistEntryNotFound(ex: WaitlistEntryNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Waitlist entry not found"))
+    }
+
+    @ExceptionHandler(ScheduleConflictException::class)
+    fun handleScheduleConflict(ex: ScheduleConflictException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse(ex.message ?: "Schedule conflict"))
+    }
+
+    @ExceptionHandler(AlreadyBookedException::class)
+    fun handleAlreadyBooked(ex: AlreadyBookedException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse(ex.message ?: "Already booked"))
+    }
+
+    @ExceptionHandler(ClassNotBookableException::class)
+    fun handleClassNotBookable(ex: ClassNotBookableException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Class not bookable"))
+    }
+
+    @ExceptionHandler(CancellationWindowClosedException::class)
+    fun handleCancellationWindowClosed(ex: CancellationWindowClosedException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Cancellation window closed"))
+    }
+
+    @ExceptionHandler(WaitlistFullException::class)
+    fun handleWaitlistFull(ex: WaitlistFullException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Waitlist full"))
+    }
+
+    @ExceptionHandler(DailyBookingLimitExceededException::class)
+    fun handleDailyBookingLimit(ex: DailyBookingLimitExceededException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Daily booking limit exceeded"))
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException::class)
+    fun handleOptimisticLocking(ex: ObjectOptimisticLockingFailureException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse("Concurrent modification detected. Please retry."))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/AdminClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/AdminClassController.kt
@@ -1,0 +1,59 @@
+package com.nickdferrara.fitify.scheduling.internal.controller
+
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/admin")
+internal class AdminClassController(
+    private val schedulingService: SchedulingService,
+) {
+
+    @PostMapping("/locations/{locationId}/classes")
+    fun createClass(
+        @PathVariable locationId: UUID,
+        @RequestBody request: CreateClassRequest,
+    ): ResponseEntity<ClassResponse> {
+        val response = schedulingService.createClass(locationId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/locations/{locationId}/classes")
+    fun listClassesByLocation(
+        @PathVariable locationId: UUID,
+    ): ResponseEntity<List<ClassResponse>> {
+        return ResponseEntity.ok(schedulingService.findClassesByLocationId(locationId))
+    }
+
+    @GetMapping("/classes/{classId}")
+    fun getClass(@PathVariable classId: UUID): ResponseEntity<ClassResponse> {
+        return ResponseEntity.ok(schedulingService.getClass(classId))
+    }
+
+    @PutMapping("/classes/{classId}")
+    fun updateClass(
+        @PathVariable classId: UUID,
+        @RequestBody request: UpdateClassRequest,
+    ): ResponseEntity<ClassResponse> {
+        return ResponseEntity.ok(schedulingService.updateClass(classId, request))
+    }
+
+    @DeleteMapping("/classes/{classId}")
+    fun cancelClass(@PathVariable classId: UUID): ResponseEntity<Void> {
+        schedulingService.cancelClass(classId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
@@ -1,0 +1,63 @@
+package com.nickdferrara.fitify.scheduling.internal.controller
+
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
+import com.nickdferrara.fitify.scheduling.internal.service.BookClassResult
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/classes")
+internal class ClassController(
+    private val schedulingService: SchedulingService,
+) {
+
+    @GetMapping
+    fun searchClasses(
+        @RequestParam(required = false) date: LocalDate?,
+        @RequestParam(required = false) classType: String?,
+        @RequestParam(required = false) coachId: UUID?,
+        @RequestParam(required = false) locationId: UUID?,
+        @RequestParam(required = false) available: Boolean?,
+        pageable: Pageable,
+    ): ResponseEntity<Page<ClassResponse>> {
+        return ResponseEntity.ok(
+            schedulingService.searchClasses(date, classType, coachId, locationId, available, pageable)
+        )
+    }
+
+    @PostMapping("/{classId}/book")
+    fun bookClass(
+        @PathVariable classId: UUID,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<Any> {
+        val userId = UUID.fromString(jwt.subject)
+        return when (val result = schedulingService.bookClass(classId, userId)) {
+            is BookClassResult.Booked -> ResponseEntity.status(HttpStatus.CREATED).body(result.booking)
+            is BookClassResult.Waitlisted -> ResponseEntity.status(HttpStatus.ACCEPTED).body(result.waitlistEntry)
+        }
+    }
+
+    @DeleteMapping("/{classId}/booking")
+    fun cancelBooking(
+        @PathVariable classId: UUID,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<Void> {
+        val userId = UUID.fromString(jwt.subject)
+        schedulingService.cancelBooking(classId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
@@ -1,0 +1,36 @@
+package com.nickdferrara.fitify.scheduling.internal.controller
+
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+internal class WaitlistController(
+    private val schedulingService: SchedulingService,
+) {
+
+    @GetMapping("/api/v1/users/me/waitlist")
+    fun getUserWaitlist(
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<List<WaitlistEntryResponse>> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(schedulingService.getUserWaitlistEntries(userId))
+    }
+
+    @DeleteMapping("/api/v1/classes/{classId}/waitlist")
+    fun removeFromWaitlist(
+        @PathVariable classId: UUID,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<Void> {
+        val userId = UUID.fromString(jwt.subject)
+        schedulingService.removeFromWaitlist(classId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/request/CreateClassRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/request/CreateClassRequest.kt
@@ -1,0 +1,14 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.request
+
+import java.time.Instant
+import java.util.UUID
+
+internal data class CreateClassRequest(
+    val name: String,
+    val classType: String,
+    val coachId: UUID,
+    val room: String? = null,
+    val startTime: Instant,
+    val endTime: Instant,
+    val capacity: Int,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/request/UpdateClassRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/request/UpdateClassRequest.kt
@@ -1,0 +1,14 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.request
+
+import java.time.Instant
+import java.util.UUID
+
+internal data class UpdateClassRequest(
+    val name: String? = null,
+    val classType: String? = null,
+    val coachId: UUID? = null,
+    val room: String? = null,
+    val startTime: Instant? = null,
+    val endTime: Instant? = null,
+    val capacity: Int? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/BookingResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/BookingResponse.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.response
+
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import java.time.Instant
+import java.util.UUID
+
+internal data class BookingResponse(
+    val id: UUID,
+    val userId: UUID,
+    val classId: UUID,
+    val className: String,
+    val startTime: Instant,
+    val status: String,
+    val bookedAt: Instant,
+)
+
+internal fun Booking.toResponse() = BookingResponse(
+    id = id!!,
+    userId = userId,
+    classId = fitnessClass.id!!,
+    className = fitnessClass.name,
+    startTime = fitnessClass.startTime,
+    status = status.name,
+    bookedAt = bookedAt!!,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/ClassResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/ClassResponse.kt
@@ -1,0 +1,38 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.response
+
+import com.nickdferrara.fitify.scheduling.internal.entities.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import java.time.Instant
+import java.util.UUID
+
+internal data class ClassResponse(
+    val id: UUID,
+    val locationId: UUID,
+    val name: String,
+    val classType: String,
+    val coachId: UUID,
+    val room: String?,
+    val startTime: Instant,
+    val endTime: Instant,
+    val capacity: Int,
+    val status: String,
+    val enrolledCount: Int,
+    val waitlistSize: Int,
+    val createdAt: Instant,
+)
+
+internal fun FitnessClass.toResponse() = ClassResponse(
+    id = id!!,
+    locationId = locationId,
+    name = name,
+    classType = classType,
+    coachId = coachId,
+    room = room,
+    startTime = startTime,
+    endTime = endTime,
+    capacity = capacity,
+    status = status.name,
+    enrolledCount = bookings.count { it.status == BookingStatus.CONFIRMED },
+    waitlistSize = waitlistEntries.size,
+    createdAt = createdAt!!,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/ErrorResponse.kt
@@ -1,0 +1,3 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.response
+
+internal data class ErrorResponse(val message: String)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/WaitlistEntryResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/dtos/response/WaitlistEntryResponse.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.fitify.scheduling.internal.dtos.response
+
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import java.time.Instant
+import java.util.UUID
+
+internal data class WaitlistEntryResponse(
+    val id: UUID,
+    val userId: UUID,
+    val classId: UUID,
+    val className: String,
+    val startTime: Instant,
+    val position: Int,
+    val createdAt: Instant,
+)
+
+internal fun WaitlistEntry.toResponse() = WaitlistEntryResponse(
+    id = id!!,
+    userId = userId,
+    classId = fitnessClass.id!!,
+    className = fitnessClass.name,
+    startTime = fitnessClass.startTime,
+    position = position,
+    createdAt = createdAt!!,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/Booking.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/Booking.kt
@@ -1,0 +1,46 @@
+package com.nickdferrara.fitify.scheduling.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "bookings")
+internal class Booking(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "user_id")
+    val userId: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fitness_class_id")
+    val fitnessClass: FitnessClass,
+
+    @Enumerated(EnumType.STRING)
+    var status: BookingStatus = BookingStatus.CONFIRMED,
+
+    @CreationTimestamp
+    @Column(name = "booked_at", updatable = false)
+    val bookedAt: Instant? = null,
+
+    @Column(name = "cancelled_at")
+    var cancelledAt: Instant? = null,
+
+    @Version
+    val version: Long = 0,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/BookingStatus.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/BookingStatus.kt
@@ -1,0 +1,6 @@
+package com.nickdferrara.fitify.scheduling.internal.entities
+
+internal enum class BookingStatus {
+    CONFIRMED,
+    CANCELLED,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/FitnessClass.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/FitnessClass.kt
@@ -1,0 +1,58 @@
+package com.nickdferrara.fitify.scheduling.internal.entities
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "fitness_classes")
+internal class FitnessClass(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "location_id")
+    var locationId: UUID,
+
+    var name: String,
+
+    @Column(name = "class_type")
+    var classType: String,
+
+    @Column(name = "coach_id")
+    var coachId: UUID,
+
+    var room: String? = null,
+
+    @Column(name = "start_time")
+    var startTime: Instant,
+
+    @Column(name = "end_time")
+    var endTime: Instant,
+
+    var capacity: Int,
+
+    @Enumerated(EnumType.STRING)
+    var status: FitnessClassStatus = FitnessClassStatus.ACTIVE,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+
+    @OneToMany(mappedBy = "fitnessClass", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val bookings: MutableList<Booking> = mutableListOf(),
+
+    @OneToMany(mappedBy = "fitnessClass", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val waitlistEntries: MutableList<WaitlistEntry> = mutableListOf(),
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/FitnessClassStatus.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/FitnessClassStatus.kt
@@ -1,0 +1,6 @@
+package com.nickdferrara.fitify.scheduling.internal.entities
+
+internal enum class FitnessClassStatus {
+    ACTIVE,
+    CANCELLED,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/WaitlistEntry.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/entities/WaitlistEntry.kt
@@ -1,0 +1,36 @@
+package com.nickdferrara.fitify.scheduling.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "waitlist_entries")
+internal class WaitlistEntry(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "user_id")
+    val userId: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fitness_class_id")
+    val fitnessClass: FitnessClass,
+
+    var position: Int,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/BookingRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/BookingRepository.kt
@@ -1,0 +1,43 @@
+package com.nickdferrara.fitify.scheduling.internal.repository
+
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.entities.BookingStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
+import java.util.UUID
+
+internal interface BookingRepository : JpaRepository<Booking, UUID> {
+
+    fun findByFitnessClassIdAndUserIdAndStatus(
+        fitnessClassId: UUID,
+        userId: UUID,
+        status: BookingStatus,
+    ): Booking?
+
+    fun countByFitnessClassIdAndStatus(fitnessClassId: UUID, status: BookingStatus): Long
+
+    @Query(
+        """
+        SELECT b FROM Booking b
+        WHERE b.userId = :userId
+          AND b.status = 'CONFIRMED'
+          AND b.fitnessClass.startTime < :endTime
+          AND b.fitnessClass.endTime > :startTime
+        """
+    )
+    fun findOverlappingBookings(userId: UUID, startTime: Instant, endTime: Instant): List<Booking>
+
+    @Query(
+        """
+        SELECT COUNT(b) FROM Booking b
+        WHERE b.userId = :userId
+          AND b.status = 'CONFIRMED'
+          AND b.fitnessClass.startTime >= :dayStart
+          AND b.fitnessClass.startTime < :dayEnd
+        """
+    )
+    fun countUserBookingsForDay(userId: UUID, dayStart: Instant, dayEnd: Instant): Long
+
+    fun findByFitnessClassIdAndStatus(fitnessClassId: UUID, status: BookingStatus): List<Booking>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassRepository.kt
@@ -1,0 +1,17 @@
+package com.nickdferrara.fitify.scheduling.internal.repository
+
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import java.time.Instant
+import java.util.UUID
+
+internal interface FitnessClassRepository :
+    JpaRepository<FitnessClass, UUID>,
+    JpaSpecificationExecutor<FitnessClass> {
+
+    fun findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(
+        locationId: UUID,
+        after: Instant,
+    ): List<FitnessClass>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassSpecifications.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassSpecifications.kt
@@ -1,0 +1,65 @@
+package com.nickdferrara.fitify.scheduling.internal.repository
+
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.entities.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClassStatus
+import jakarta.persistence.criteria.JoinType
+import org.springframework.data.jpa.domain.Specification
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+internal object FitnessClassSpecifications {
+
+    fun hasDate(date: LocalDate): Specification<FitnessClass> {
+        val dayStart = date.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val dayEnd = date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+        return Specification { root, _, cb ->
+            cb.and(
+                cb.greaterThanOrEqualTo(root.get("startTime"), dayStart),
+                cb.lessThan(root.get("startTime"), dayEnd),
+            )
+        }
+    }
+
+    fun hasClassType(classType: String): Specification<FitnessClass> =
+        Specification { root, _, cb ->
+            cb.equal(cb.lower(root.get("classType")), classType.lowercase())
+        }
+
+    fun hasCoach(coachId: UUID): Specification<FitnessClass> =
+        Specification { root, _, cb ->
+            cb.equal(root.get<UUID>("coachId"), coachId)
+        }
+
+    fun hasLocation(locationId: UUID): Specification<FitnessClass> =
+        Specification { root, _, cb ->
+            cb.equal(root.get<UUID>("locationId"), locationId)
+        }
+
+    fun hasAvailability(): Specification<FitnessClass> =
+        Specification { root, query, cb ->
+            val bookingJoin = root.join<FitnessClass, Booking>("bookings", JoinType.LEFT)
+            bookingJoin.on(cb.equal(bookingJoin.get<BookingStatus>("status"), BookingStatus.CONFIRMED))
+            query?.groupBy(root.get<UUID>("id"))
+            query?.having(cb.lt(cb.count(bookingJoin.get<UUID>("id")), root.get("capacity")))
+            cb.conjunction()
+        }
+
+    fun isActive(): Specification<FitnessClass> =
+        Specification { root, _, cb ->
+            cb.equal(root.get<FitnessClassStatus>("status"), FitnessClassStatus.ACTIVE)
+        }
+
+    fun isFuture(): Specification<FitnessClass> =
+        Specification { root, _, cb ->
+            cb.greaterThan(root.get("startTime"), Instant.now())
+        }
+
+    fun combine(vararg specs: Specification<FitnessClass>?): Specification<FitnessClass> {
+        return specs.filterNotNull().reduceOrNull { acc, spec -> acc.and(spec) }
+            ?: Specification.where(null)
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/WaitlistEntryRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/WaitlistEntryRepository.kt
@@ -1,0 +1,16 @@
+package com.nickdferrara.fitify.scheduling.internal.repository
+
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface WaitlistEntryRepository : JpaRepository<WaitlistEntry, UUID> {
+
+    fun findByFitnessClassIdOrderByPositionAsc(fitnessClassId: UUID): List<WaitlistEntry>
+
+    fun findByUserIdOrderByCreatedAtDesc(userId: UUID): List<WaitlistEntry>
+
+    fun findByFitnessClassIdAndUserId(fitnessClassId: UUID, userId: UUID): WaitlistEntry?
+
+    fun countByFitnessClassId(fitnessClassId: UUID): Long
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingEventListener.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.scheduling.internal.service
+
+import org.springframework.stereotype.Component
+
+@Component
+internal class SchedulingEventListener {
+
+    // Placeholder for cross-module event handling.
+    // Future listeners:
+    // - BusinessRuleUpdatedEvent: update cancellationWindowHours, maxWaitlistSize, maxBookingsPerDay
+    // - SubscriptionExpiredEvent: prevent bookings for expired subscriptions
+    // - LocationDeactivatedEvent: cancel all future classes at deactivated location
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingService.kt
@@ -1,0 +1,372 @@
+package com.nickdferrara.fitify.scheduling.internal.service
+
+import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
+import com.nickdferrara.fitify.scheduling.ClassBookedEvent
+import com.nickdferrara.fitify.scheduling.ClassFullEvent
+import com.nickdferrara.fitify.scheduling.ClassSummary
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.BookingResponse
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.toResponse
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.entities.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClassStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import com.nickdferrara.fitify.scheduling.internal.repository.BookingRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassSpecifications
+import com.nickdferrara.fitify.scheduling.internal.repository.WaitlistEntryRepository
+import com.nickdferrara.fitify.shared.DomainError
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Service
+internal class SchedulingService(
+    private val fitnessClassRepository: FitnessClassRepository,
+    private val bookingRepository: BookingRepository,
+    private val waitlistEntryRepository: WaitlistEntryRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+) : SchedulingApi {
+
+    var cancellationWindowHours: Long = 24
+    var maxWaitlistSize: Int = 20
+    var maxBookingsPerDay: Int = 3
+
+    // --- Public API (cross-module) ---
+
+    override fun findClassById(id: UUID): Result<ClassSummary, DomainError> {
+        val fitnessClass = fitnessClassRepository.findById(id).orElse(null)
+            ?: return Result.Failure(NotFoundError("Class not found: $id"))
+        return Result.Success(fitnessClass.toSummary())
+    }
+
+    override fun findUpcomingClassesByLocationId(locationId: UUID): List<ClassSummary> {
+        return fitnessClassRepository
+            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
+            .map { it.toSummary() }
+    }
+
+    // --- Search ---
+
+    fun searchClasses(
+        date: LocalDate?,
+        classType: String?,
+        coachId: UUID?,
+        locationId: UUID?,
+        available: Boolean?,
+        pageable: Pageable,
+    ): Page<ClassResponse> {
+        val spec = FitnessClassSpecifications.combine(
+            FitnessClassSpecifications.isActive(),
+            FitnessClassSpecifications.isFuture(),
+            date?.let { FitnessClassSpecifications.hasDate(it) },
+            classType?.let { FitnessClassSpecifications.hasClassType(it) },
+            coachId?.let { FitnessClassSpecifications.hasCoach(it) },
+            locationId?.let { FitnessClassSpecifications.hasLocation(it) },
+            if (available == true) FitnessClassSpecifications.hasAvailability() else null,
+        )
+        return fitnessClassRepository.findAll(spec, pageable).map { it.toResponse() }
+    }
+
+    // --- Admin CRUD ---
+
+    @Transactional
+    fun createClass(locationId: UUID, request: CreateClassRequest): ClassResponse {
+        val fitnessClass = FitnessClass(
+            locationId = locationId,
+            name = request.name,
+            classType = request.classType,
+            coachId = request.coachId,
+            room = request.room,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            capacity = request.capacity,
+        )
+        return fitnessClassRepository.save(fitnessClass).toResponse()
+    }
+
+    fun findClassesByLocationId(locationId: UUID): List<ClassResponse> {
+        return fitnessClassRepository
+            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
+            .map { it.toResponse() }
+    }
+
+    fun getClass(classId: UUID): ClassResponse {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+        return fitnessClass.toResponse()
+    }
+
+    @Transactional
+    fun updateClass(classId: UUID, request: UpdateClassRequest): ClassResponse {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+
+        request.name?.let { fitnessClass.name = it }
+        request.classType?.let { fitnessClass.classType = it }
+        request.coachId?.let { fitnessClass.coachId = it }
+        request.room?.let { fitnessClass.room = it }
+        request.startTime?.let { fitnessClass.startTime = it }
+        request.endTime?.let { fitnessClass.endTime = it }
+        request.capacity?.let { fitnessClass.capacity = it }
+
+        return fitnessClassRepository.save(fitnessClass).toResponse()
+    }
+
+    @Transactional
+    fun cancelClass(classId: UUID) {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+
+        fitnessClass.status = FitnessClassStatus.CANCELLED
+
+        val confirmedBookings = bookingRepository
+            .findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
+        confirmedBookings.forEach { booking ->
+            booking.status = BookingStatus.CANCELLED
+            booking.cancelledAt = Instant.now()
+            bookingRepository.save(booking)
+        }
+
+        val waitlistEntries = waitlistEntryRepository
+            .findByFitnessClassIdOrderByPositionAsc(classId)
+        waitlistEntryRepository.deleteAll(waitlistEntries)
+
+        fitnessClassRepository.save(fitnessClass)
+    }
+
+    // --- Booking ---
+
+    @Transactional
+    fun bookClass(classId: UUID, userId: UUID): BookClassResult {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+
+        if (fitnessClass.status != FitnessClassStatus.ACTIVE) {
+            throw ClassNotBookableException(classId, "Class is not active")
+        }
+        if (fitnessClass.startTime.isBefore(Instant.now())) {
+            throw ClassNotBookableException(classId, "Class has already started")
+        }
+
+        val existingBooking = bookingRepository
+            .findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED)
+        if (existingBooking != null) {
+            throw AlreadyBookedException(classId, userId)
+        }
+
+        val overlapping = bookingRepository
+            .findOverlappingBookings(userId, fitnessClass.startTime, fitnessClass.endTime)
+        if (overlapping.isNotEmpty()) {
+            throw ScheduleConflictException(userId, fitnessClass.startTime, fitnessClass.endTime)
+        }
+
+        val dayStart = fitnessClass.startTime.atZone(ZoneOffset.UTC).toLocalDate()
+            .atStartOfDay().toInstant(ZoneOffset.UTC)
+        val dayEnd = dayStart.atZone(ZoneOffset.UTC).toLocalDate()
+            .plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+        val dailyCount = bookingRepository.countUserBookingsForDay(userId, dayStart, dayEnd)
+        if (dailyCount >= maxBookingsPerDay) {
+            throw DailyBookingLimitExceededException(userId, maxBookingsPerDay)
+        }
+
+        // TODO: Check subscription status when subscription module is implemented
+
+        val confirmedCount = bookingRepository
+            .countByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
+
+        if (confirmedCount < fitnessClass.capacity) {
+            val booking = Booking(
+                userId = userId,
+                fitnessClass = fitnessClass,
+            )
+            val saved = bookingRepository.save(booking)
+
+            eventPublisher.publishEvent(
+                ClassBookedEvent(
+                    userId = userId,
+                    classId = classId,
+                    className = fitnessClass.name,
+                    startTime = fitnessClass.startTime,
+                )
+            )
+
+            return BookClassResult.Booked(saved.toResponse())
+        }
+
+        val waitlistCount = waitlistEntryRepository.countByFitnessClassId(classId)
+        if (waitlistCount >= maxWaitlistSize) {
+            throw WaitlistFullException(classId)
+        }
+
+        val existingWaitlist = waitlistEntryRepository
+            .findByFitnessClassIdAndUserId(classId, userId)
+        if (existingWaitlist != null) {
+            throw AlreadyBookedException(classId, userId)
+        }
+
+        val entry = WaitlistEntry(
+            userId = userId,
+            fitnessClass = fitnessClass,
+            position = (waitlistCount + 1).toInt(),
+        )
+        val savedEntry = waitlistEntryRepository.save(entry)
+
+        eventPublisher.publishEvent(
+            ClassFullEvent(
+                classId = classId,
+                className = fitnessClass.name,
+                waitlistSize = (waitlistCount + 1).toInt(),
+            )
+        )
+
+        return BookClassResult.Waitlisted(savedEntry.toResponse())
+    }
+
+    @Transactional
+    fun cancelBooking(classId: UUID, userId: UUID) {
+        val booking = bookingRepository
+            .findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED)
+            ?: throw BookingNotFoundException(classId, userId)
+
+        val hoursUntilClass = java.time.Duration.between(
+            Instant.now(), booking.fitnessClass.startTime
+        ).toHours()
+        if (hoursUntilClass < cancellationWindowHours) {
+            throw CancellationWindowClosedException(classId, cancellationWindowHours)
+        }
+
+        booking.status = BookingStatus.CANCELLED
+        booking.cancelledAt = Instant.now()
+        bookingRepository.save(booking)
+
+        eventPublisher.publishEvent(
+            BookingCancelledEvent(
+                userId = userId,
+                classId = classId,
+                cancelledAt = booking.cancelledAt!!,
+            )
+        )
+
+        promoteFromWaitlist(booking.fitnessClass)
+    }
+
+    // --- Waitlist ---
+
+    fun getUserWaitlistEntries(userId: UUID): List<WaitlistEntryResponse> {
+        return waitlistEntryRepository.findByUserIdOrderByCreatedAtDesc(userId)
+            .map { it.toResponse() }
+    }
+
+    @Transactional
+    fun removeFromWaitlist(classId: UUID, userId: UUID) {
+        val entry = waitlistEntryRepository.findByFitnessClassIdAndUserId(classId, userId)
+            ?: throw WaitlistEntryNotFoundException(classId, userId)
+        waitlistEntryRepository.delete(entry)
+
+        val remaining = waitlistEntryRepository
+            .findByFitnessClassIdOrderByPositionAsc(classId)
+        remaining.forEachIndexed { index, e ->
+            e.position = index + 1
+            waitlistEntryRepository.save(e)
+        }
+    }
+
+    // --- Private helpers ---
+
+    private fun promoteFromWaitlist(fitnessClass: FitnessClass) {
+        val waitlist = waitlistEntryRepository
+            .findByFitnessClassIdOrderByPositionAsc(fitnessClass.id!!)
+        if (waitlist.isEmpty()) return
+
+        for (entry in waitlist) {
+            val overlapping = bookingRepository
+                .findOverlappingBookings(entry.userId, fitnessClass.startTime, fitnessClass.endTime)
+            if (overlapping.isNotEmpty()) continue
+
+            val booking = Booking(
+                userId = entry.userId,
+                fitnessClass = fitnessClass,
+            )
+            bookingRepository.save(booking)
+            waitlistEntryRepository.delete(entry)
+
+            val remaining = waitlistEntryRepository
+                .findByFitnessClassIdOrderByPositionAsc(fitnessClass.id!!)
+            remaining.forEachIndexed { index, e ->
+                e.position = index + 1
+                waitlistEntryRepository.save(e)
+            }
+
+            eventPublisher.publishEvent(
+                WaitlistPromotedEvent(
+                    userId = entry.userId,
+                    classId = fitnessClass.id!!,
+                    className = fitnessClass.name,
+                    startTime = fitnessClass.startTime,
+                )
+            )
+            return
+        }
+    }
+
+    private fun FitnessClass.toSummary() = ClassSummary(
+        id = id!!,
+        name = name,
+        classType = classType,
+        startTime = startTime,
+        endTime = endTime,
+        locationId = locationId,
+        coachId = coachId,
+    )
+}
+
+// --- Sealed result type for bookClass ---
+
+internal sealed class BookClassResult {
+    data class Booked(val booking: BookingResponse) : BookClassResult()
+    data class Waitlisted(val waitlistEntry: WaitlistEntryResponse) : BookClassResult()
+}
+
+// --- Exception classes ---
+
+internal class FitnessClassNotFoundException(id: UUID) :
+    RuntimeException("Fitness class not found: $id")
+
+internal class BookingNotFoundException(classId: UUID, userId: UUID) :
+    RuntimeException("Booking not found for class $classId and user $userId")
+
+internal class ScheduleConflictException(userId: UUID, startTime: Instant, endTime: Instant) :
+    RuntimeException("User $userId has an overlapping booking between $startTime and $endTime")
+
+internal class AlreadyBookedException(classId: UUID, userId: UUID) :
+    RuntimeException("User $userId is already booked for class $classId")
+
+internal class ClassNotBookableException(classId: UUID, reason: String) :
+    RuntimeException("Class $classId is not bookable: $reason")
+
+internal class CancellationWindowClosedException(classId: UUID, windowHours: Long) :
+    RuntimeException("Cancellation window of ${windowHours}h has closed for class $classId")
+
+internal class WaitlistFullException(classId: UUID) :
+    RuntimeException("Waitlist is full for class $classId")
+
+internal class DailyBookingLimitExceededException(userId: UUID, limit: Int) :
+    RuntimeException("User $userId has reached the daily booking limit of $limit")
+
+internal class WaitlistEntryNotFoundException(classId: UUID, userId: UUID) :
+    RuntimeException("Waitlist entry not found for class $classId and user $userId")

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingServiceTest.kt
@@ -1,0 +1,556 @@
+package com.nickdferrara.fitify.scheduling.internal
+
+import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
+import com.nickdferrara.fitify.scheduling.ClassBookedEvent
+import com.nickdferrara.fitify.scheduling.ClassFullEvent
+import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.entities.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClassStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import com.nickdferrara.fitify.scheduling.internal.repository.BookingRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.WaitlistEntryRepository
+import com.nickdferrara.fitify.scheduling.internal.service.AlreadyBookedException
+import com.nickdferrara.fitify.scheduling.internal.service.BookClassResult
+import com.nickdferrara.fitify.scheduling.internal.service.BookingNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.CancellationWindowClosedException
+import com.nickdferrara.fitify.scheduling.internal.service.ClassNotBookableException
+import com.nickdferrara.fitify.scheduling.internal.service.DailyBookingLimitExceededException
+import com.nickdferrara.fitify.scheduling.internal.service.FitnessClassNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.ScheduleConflictException
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.WaitlistEntryNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.service.WaitlistFullException
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Optional
+import java.util.UUID
+
+class SchedulingServiceTest {
+
+    private val fitnessClassRepository = mockk<FitnessClassRepository>()
+    private val bookingRepository = mockk<BookingRepository>()
+    private val waitlistEntryRepository = mockk<WaitlistEntryRepository>()
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    private val service = SchedulingService(
+        fitnessClassRepository, bookingRepository, waitlistEntryRepository, eventPublisher,
+    )
+
+    private val locationId: UUID = UUID.randomUUID()
+    private val coachId: UUID = UUID.randomUUID()
+    private val userId: UUID = UUID.randomUUID()
+
+    private fun buildFitnessClass(
+        id: UUID = UUID.randomUUID(),
+        name: String = "Morning Yoga",
+        classType: String = "yoga",
+        capacity: Int = 20,
+        status: FitnessClassStatus = FitnessClassStatus.ACTIVE,
+        startTime: Instant = Instant.now().plus(2, ChronoUnit.DAYS),
+        endTime: Instant = Instant.now().plus(2, ChronoUnit.DAYS).plus(1, ChronoUnit.HOURS),
+    ) = FitnessClass(
+        id = id,
+        locationId = locationId,
+        name = name,
+        classType = classType,
+        coachId = coachId,
+        room = "Studio A",
+        startTime = startTime,
+        endTime = endTime,
+        capacity = capacity,
+        status = status,
+        createdAt = Instant.now(),
+    )
+
+    private fun buildBooking(
+        id: UUID = UUID.randomUUID(),
+        fitnessClass: FitnessClass,
+        userId: UUID = this.userId,
+        status: BookingStatus = BookingStatus.CONFIRMED,
+    ) = Booking(
+        id = id,
+        userId = userId,
+        fitnessClass = fitnessClass,
+        status = status,
+        bookedAt = Instant.now(),
+    )
+
+    // --- Public API Tests ---
+
+    @Test
+    fun `findClassById returns summary when class exists`() {
+        val id = UUID.randomUUID()
+        val fc = buildFitnessClass(id = id)
+        every { fitnessClassRepository.findById(id) } returns Optional.of(fc)
+
+        val result = service.findClassById(id)
+
+        assertTrue(result is Result.Success)
+        val summary = (result as Result.Success).value
+        assertEquals(id, summary.id)
+        assertEquals("Morning Yoga", summary.name)
+    }
+
+    @Test
+    fun `findClassById returns failure when class does not exist`() {
+        val id = UUID.randomUUID()
+        every { fitnessClassRepository.findById(id) } returns Optional.empty()
+
+        val result = service.findClassById(id)
+
+        assertTrue(result is Result.Failure)
+        val error = (result as Result.Failure).error
+        assertTrue(error is NotFoundError)
+    }
+
+    @Test
+    fun `findUpcomingClassesByLocationId delegates to repository`() {
+        val fc = buildFitnessClass()
+        every {
+            fitnessClassRepository.findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, any())
+        } returns listOf(fc)
+
+        val results = service.findUpcomingClassesByLocationId(locationId)
+
+        assertEquals(1, results.size)
+        assertEquals("Morning Yoga", results[0].name)
+    }
+
+    // --- Admin CRUD Tests ---
+
+    @Test
+    fun `createClass persists and returns response`() {
+        val request = CreateClassRequest(
+            name = "HIIT Blast",
+            classType = "hiit",
+            coachId = coachId,
+            room = "Studio B",
+            startTime = Instant.now().plus(1, ChronoUnit.DAYS),
+            endTime = Instant.now().plus(1, ChronoUnit.DAYS).plus(45, ChronoUnit.MINUTES),
+            capacity = 15,
+        )
+
+        val savedId = UUID.randomUUID()
+        every { fitnessClassRepository.save(any()) } answers {
+            val fc = firstArg<FitnessClass>()
+            FitnessClass(
+                id = savedId,
+                locationId = fc.locationId,
+                name = fc.name,
+                classType = fc.classType,
+                coachId = fc.coachId,
+                room = fc.room,
+                startTime = fc.startTime,
+                endTime = fc.endTime,
+                capacity = fc.capacity,
+                createdAt = Instant.now(),
+            )
+        }
+
+        val response = service.createClass(locationId, request)
+
+        assertEquals(savedId, response.id)
+        assertEquals("HIIT Blast", response.name)
+        assertEquals("hiit", response.classType)
+        assertEquals(15, response.capacity)
+    }
+
+    @Test
+    fun `getClass throws when class not found`() {
+        val id = UUID.randomUUID()
+        every { fitnessClassRepository.findById(id) } returns Optional.empty()
+
+        assertThrows<FitnessClassNotFoundException> {
+            service.getClass(id)
+        }
+    }
+
+    @Test
+    fun `updateClass updates fields and returns response`() {
+        val id = UUID.randomUUID()
+        val existing = buildFitnessClass(id = id, name = "Old Name", capacity = 10)
+        every { fitnessClassRepository.findById(id) } returns Optional.of(existing)
+        every { fitnessClassRepository.save(any()) } answers { firstArg() }
+
+        val request = UpdateClassRequest(name = "New Name", capacity = 25)
+
+        val response = service.updateClass(id, request)
+
+        assertEquals("New Name", response.name)
+        assertEquals(25, response.capacity)
+        assertEquals("Studio A", response.room)
+    }
+
+    @Test
+    fun `cancelClass sets status and cancels all bookings`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val booking = buildBooking(fitnessClass = fc)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED) } returns listOf(booking)
+        every { bookingRepository.save(any()) } answers { firstArg() }
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns emptyList()
+        every { waitlistEntryRepository.deleteAll(any<List<WaitlistEntry>>()) } returns Unit
+        every { fitnessClassRepository.save(any()) } answers { firstArg() }
+
+        service.cancelClass(classId)
+
+        assertEquals(FitnessClassStatus.CANCELLED, fc.status)
+        assertEquals(BookingStatus.CANCELLED, booking.status)
+    }
+
+    // --- Booking Tests ---
+
+    @Test
+    fun `bookClass creates booking when capacity available`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId, capacity = 20)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+        every { bookingRepository.findOverlappingBookings(userId, any(), any()) } returns emptyList()
+        every { bookingRepository.countUserBookingsForDay(userId, any(), any()) } returns 0
+        every { bookingRepository.countByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED) } returns 5
+        every { bookingRepository.save(any()) } answers {
+            val b = firstArg<Booking>()
+            Booking(
+                id = UUID.randomUUID(),
+                userId = b.userId,
+                fitnessClass = b.fitnessClass,
+                status = b.status,
+                bookedAt = Instant.now(),
+            )
+        }
+
+        val result = service.bookClass(classId, userId)
+
+        assertTrue(result is BookClassResult.Booked)
+        val eventSlot = slot<ClassBookedEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(classId, eventSlot.captured.classId)
+        assertEquals(userId, eventSlot.captured.userId)
+    }
+
+    @Test
+    fun `bookClass adds to waitlist when class is full`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId, capacity = 1)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+        every { bookingRepository.findOverlappingBookings(userId, any(), any()) } returns emptyList()
+        every { bookingRepository.countUserBookingsForDay(userId, any(), any()) } returns 0
+        every { bookingRepository.countByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED) } returns 1
+        every { waitlistEntryRepository.countByFitnessClassId(classId) } returns 0
+        every { waitlistEntryRepository.findByFitnessClassIdAndUserId(classId, userId) } returns null
+        every { waitlistEntryRepository.save(any()) } answers {
+            val e = firstArg<WaitlistEntry>()
+            WaitlistEntry(
+                id = UUID.randomUUID(),
+                userId = e.userId,
+                fitnessClass = e.fitnessClass,
+                position = e.position,
+                createdAt = Instant.now(),
+            )
+        }
+
+        val result = service.bookClass(classId, userId)
+
+        assertTrue(result is BookClassResult.Waitlisted)
+        val eventSlot = slot<ClassFullEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(classId, eventSlot.captured.classId)
+    }
+
+    @Test
+    fun `bookClass throws when class is cancelled`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId, status = FitnessClassStatus.CANCELLED)
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+
+        assertThrows<ClassNotBookableException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when class has already started`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(
+            id = classId,
+            startTime = Instant.now().minus(1, ChronoUnit.HOURS),
+            endTime = Instant.now(),
+        )
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+
+        assertThrows<ClassNotBookableException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when user already booked`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val existing = buildBooking(fitnessClass = fc)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns existing
+
+        assertThrows<AlreadyBookedException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when overlapping booking exists`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val otherFc = buildFitnessClass()
+        val overlap = buildBooking(fitnessClass = otherFc)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+        every { bookingRepository.findOverlappingBookings(userId, any(), any()) } returns listOf(overlap)
+
+        assertThrows<ScheduleConflictException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when daily booking limit exceeded`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+        every { bookingRepository.findOverlappingBookings(userId, any(), any()) } returns emptyList()
+        every { bookingRepository.countUserBookingsForDay(userId, any(), any()) } returns 3
+
+        assertThrows<DailyBookingLimitExceededException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when class not found`() {
+        val classId = UUID.randomUUID()
+        every { fitnessClassRepository.findById(classId) } returns Optional.empty()
+
+        assertThrows<FitnessClassNotFoundException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    @Test
+    fun `bookClass throws when waitlist is full`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId, capacity = 1)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+        every { bookingRepository.findOverlappingBookings(userId, any(), any()) } returns emptyList()
+        every { bookingRepository.countUserBookingsForDay(userId, any(), any()) } returns 0
+        every { bookingRepository.countByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED) } returns 1
+        every { waitlistEntryRepository.countByFitnessClassId(classId) } returns 20
+
+        assertThrows<WaitlistFullException> {
+            service.bookClass(classId, userId)
+        }
+    }
+
+    // --- Cancellation Tests ---
+
+    @Test
+    fun `cancelBooking soft-deletes booking and publishes event`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val booking = buildBooking(fitnessClass = fc)
+
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns booking
+        every { bookingRepository.save(any()) } answers { firstArg() }
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns emptyList()
+
+        service.cancelBooking(classId, userId)
+
+        assertEquals(BookingStatus.CANCELLED, booking.status)
+        assertTrue(booking.cancelledAt != null)
+
+        val eventSlot = slot<BookingCancelledEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(classId, eventSlot.captured.classId)
+        assertEquals(userId, eventSlot.captured.userId)
+    }
+
+    @Test
+    fun `cancelBooking throws when cancellation window closed`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(
+            id = classId,
+            startTime = Instant.now().plus(1, ChronoUnit.HOURS),
+            endTime = Instant.now().plus(2, ChronoUnit.HOURS),
+        )
+        val booking = buildBooking(fitnessClass = fc)
+
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns booking
+
+        assertThrows<CancellationWindowClosedException> {
+            service.cancelBooking(classId, userId)
+        }
+    }
+
+    @Test
+    fun `cancelBooking throws when booking not found`() {
+        val classId = UUID.randomUUID()
+
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns null
+
+        assertThrows<BookingNotFoundException> {
+            service.cancelBooking(classId, userId)
+        }
+    }
+
+    @Test
+    fun `cancelBooking promotes first eligible waitlist entry`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val booking = buildBooking(fitnessClass = fc)
+        val waitlistUserId = UUID.randomUUID()
+        val waitlistEntry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = waitlistUserId,
+            fitnessClass = fc,
+            position = 1,
+            createdAt = Instant.now(),
+        )
+
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns booking
+        every { bookingRepository.save(any()) } answers { firstArg() }
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns listOf(waitlistEntry) andThen emptyList()
+        every { bookingRepository.findOverlappingBookings(waitlistUserId, any(), any()) } returns emptyList()
+        every { waitlistEntryRepository.delete(waitlistEntry) } returns Unit
+
+        service.cancelBooking(classId, userId)
+
+        verify { bookingRepository.save(match<Booking> { it.userId == waitlistUserId }) }
+
+        val eventSlot = slot<WaitlistPromotedEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(waitlistUserId, eventSlot.captured.userId)
+        assertEquals(classId, eventSlot.captured.classId)
+    }
+
+    @Test
+    fun `cancelBooking skips waitlist entry with overlapping booking`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val booking = buildBooking(fitnessClass = fc)
+        val conflictUserId = UUID.randomUUID()
+        val eligibleUserId = UUID.randomUUID()
+        val conflictEntry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = conflictUserId,
+            fitnessClass = fc,
+            position = 1,
+            createdAt = Instant.now(),
+        )
+        val eligibleEntry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = eligibleUserId,
+            fitnessClass = fc,
+            position = 2,
+            createdAt = Instant.now(),
+        )
+
+        every { bookingRepository.findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED) } returns booking
+        every { bookingRepository.save(any()) } answers { firstArg() }
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns
+            listOf(conflictEntry, eligibleEntry) andThen emptyList()
+        every { bookingRepository.findOverlappingBookings(conflictUserId, any(), any()) } returns listOf(buildBooking(fitnessClass = buildFitnessClass(), userId = conflictUserId))
+        every { bookingRepository.findOverlappingBookings(eligibleUserId, any(), any()) } returns emptyList()
+        every { waitlistEntryRepository.delete(eligibleEntry) } returns Unit
+
+        service.cancelBooking(classId, userId)
+
+        verify { bookingRepository.save(match<Booking> { it.userId == eligibleUserId }) }
+        verify(exactly = 0) { bookingRepository.save(match<Booking> { it.userId == conflictUserId }) }
+    }
+
+    // --- Waitlist Tests ---
+
+    @Test
+    fun `getUserWaitlistEntries returns user entries`() {
+        val fc = buildFitnessClass()
+        val entry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = userId,
+            fitnessClass = fc,
+            position = 1,
+            createdAt = Instant.now(),
+        )
+        every { waitlistEntryRepository.findByUserIdOrderByCreatedAtDesc(userId) } returns listOf(entry)
+
+        val results = service.getUserWaitlistEntries(userId)
+
+        assertEquals(1, results.size)
+        assertEquals(userId, results[0].userId)
+    }
+
+    @Test
+    fun `removeFromWaitlist deletes entry and reorders positions`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val entry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = userId,
+            fitnessClass = fc,
+            position = 1,
+            createdAt = Instant.now(),
+        )
+        val otherEntry = WaitlistEntry(
+            id = UUID.randomUUID(),
+            userId = UUID.randomUUID(),
+            fitnessClass = fc,
+            position = 2,
+            createdAt = Instant.now(),
+        )
+
+        every { waitlistEntryRepository.findByFitnessClassIdAndUserId(classId, userId) } returns entry
+        every { waitlistEntryRepository.delete(entry) } returns Unit
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns listOf(otherEntry)
+        every { waitlistEntryRepository.save(any()) } answers { firstArg() }
+
+        service.removeFromWaitlist(classId, userId)
+
+        verify { waitlistEntryRepository.delete(entry) }
+        assertEquals(1, otherEntry.position)
+    }
+
+    @Test
+    fun `removeFromWaitlist throws when entry not found`() {
+        val classId = UUID.randomUUID()
+
+        every { waitlistEntryRepository.findByFitnessClassIdAndUserId(classId, userId) } returns null
+
+        assertThrows<WaitlistEntryNotFoundException> {
+            service.removeFromWaitlist(classId, userId)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the scheduling module with fitness class CRUD, booking with optimistic locking, waitlist management (FIFO), cancellation with configurable window, and class search using the Specification pattern
- Follows the established module conventions from coaching, identity, and location modules
- Adds 25 unit tests covering all business logic paths

## Details

### Public API & Events
- `SchedulingApi` with `ClassSummary`, `findClassById`, and `findUpcomingClassesByLocationId` for cross-module use
- Domain events: `ClassBookedEvent`, `BookingCancelledEvent`, `ClassFullEvent`, `WaitlistPromotedEvent`

### Entities
- `FitnessClass` — core entity with location, coach, capacity, and status tracking
- `Booking` — with `@Version` for optimistic locking and soft-delete via status
- `WaitlistEntry` — position-based FIFO ordering

### Search
- `FitnessClassSpecifications` — composable JPA `Specification` functions (`hasDate`, `hasClassType`, `hasCoach`, `hasLocation`, `hasAvailability`, `isActive`, `isFuture`) with a `combine()` utility

### Booking Logic (`SchedulingService.bookClass`)
- Validates class is active and in the future
- Checks for duplicate bookings and schedule overlaps
- Enforces configurable daily booking limit (default 3)
- Returns `BookClassResult.Booked` (201) or `BookClassResult.Waitlisted` (202) sealed class
- Publishes `ClassBookedEvent` or `ClassFullEvent`

### Cancellation (`SchedulingService.cancelBooking`)
- Enforces configurable cancellation window (default 24h)
- Soft-deletes booking (status → CANCELLED)
- Auto-promotes first eligible waitlist entry, re-validating overlap constraints
- Publishes `BookingCancelledEvent` and `WaitlistPromotedEvent`

### Controllers
- `AdminClassController` — POST/GET `/api/v1/admin/locations/{locationId}/classes`, GET/PUT/DELETE `/api/v1/admin/classes/{classId}`
- `ClassController` — GET `/api/v1/classes` (search), POST `/{classId}/book`, DELETE `/{classId}/booking`
- `WaitlistController` — GET `/api/v1/users/me/waitlist`, DELETE `/api/v1/classes/{classId}/waitlist`

### Exception Handling
- `SchedulingExceptionHandler` with mapped responses for 9 exception types (404/409/400) including `ObjectOptimisticLockingFailureException`

## Test plan

- [x] `./gradlew test` — all 25 scheduling unit tests pass
- [x] `./gradlew build` — compiles and passes JaCoCo coverage
- [x] Verify modulith structure test passes in CI
- [x] Manual smoke test of booking/cancellation/waitlist flows against running instance

Closes #5