### PR TITLE
feat: implement subscription module with Stripe integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     // Keycloak
     implementation("org.keycloak:keycloak-admin-client:26.0.0")
 
+    // Stripe
+    implementation("com.stripe:stripe-java:28.2.0")
+
     // Database
     runtimeOnly("org.postgresql:postgresql")
 

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/SecurityConfig.kt
@@ -25,6 +25,7 @@ internal class SecurityConfig {
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it.requestMatchers("/api/v1/auth/**").permitAll()
+                it.requestMatchers("/api/v1/webhooks/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 it.anyRequest().authenticated()

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionApi.kt
@@ -1,3 +1,17 @@
 package com.nickdferrara.fitify.subscription
 
-interface SubscriptionApi
+import java.time.Instant
+import java.util.UUID
+
+data class SubscriptionSummary(
+    val id: UUID,
+    val userId: UUID,
+    val planType: String,
+    val status: String,
+    val currentPeriodEnd: Instant?,
+)
+
+interface SubscriptionApi {
+    fun findActiveSubscriptionByUserId(userId: UUID): SubscriptionSummary?
+    fun hasActiveSubscription(userId: UUID): Boolean
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionCancelledEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionCancelledEvent.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.subscription
+
+import java.time.Instant
+import java.util.UUID
+
+data class SubscriptionCancelledEvent(
+    val subscriptionId: UUID,
+    val userId: UUID,
+    val effectiveDate: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionCreatedEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionCreatedEvent.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.subscription
+
+import java.util.UUID
+
+data class SubscriptionCreatedEvent(
+    val subscriptionId: UUID,
+    val userId: UUID,
+    val planType: String,
+    val stripeSubscriptionId: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionExpiredEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionExpiredEvent.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.subscription
+
+import java.util.UUID
+
+data class SubscriptionExpiredEvent(
+    val subscriptionId: UUID,
+    val userId: UUID,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionRenewedEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionRenewedEvent.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.subscription
+
+import java.time.Instant
+import java.util.UUID
+
+data class SubscriptionRenewedEvent(
+    val subscriptionId: UUID,
+    val userId: UUID,
+    val newPeriodEnd: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/SubscriptionService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/SubscriptionService.kt
@@ -1,7 +1,0 @@
-package com.nickdferrara.fitify.subscription.internal
-
-import com.nickdferrara.fitify.subscription.SubscriptionApi
-import org.springframework.stereotype.Service
-
-@Service
-internal class SubscriptionService : SubscriptionApi

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/advices/SubscriptionExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/advices/SubscriptionExceptionHandler.kt
@@ -1,0 +1,60 @@
+package com.nickdferrara.fitify.subscription.internal.advices
+
+import com.nickdferrara.fitify.subscription.internal.controller.StripeWebhookController
+import com.nickdferrara.fitify.subscription.internal.controller.SubscriptionController
+import com.nickdferrara.fitify.subscription.internal.dtos.response.ErrorResponse
+import com.nickdferrara.fitify.subscription.internal.exception.ActiveSubscriptionExistsException
+import com.nickdferrara.fitify.subscription.internal.exception.InvalidWebhookSignatureException
+import com.nickdferrara.fitify.subscription.internal.exception.StripeException
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionNotFoundException
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionPlanNotFoundException
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionStateException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(
+    assignableTypes = [
+        SubscriptionController::class,
+        StripeWebhookController::class,
+    ]
+)
+internal class SubscriptionExceptionHandler {
+
+    @ExceptionHandler(SubscriptionNotFoundException::class)
+    fun handleNotFound(ex: SubscriptionNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Subscription not found"))
+    }
+
+    @ExceptionHandler(SubscriptionPlanNotFoundException::class)
+    fun handlePlanNotFound(ex: SubscriptionPlanNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Subscription plan not found"))
+    }
+
+    @ExceptionHandler(ActiveSubscriptionExistsException::class)
+    fun handleConflict(ex: ActiveSubscriptionExistsException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse(ex.message ?: "Active subscription already exists"))
+    }
+
+    @ExceptionHandler(InvalidWebhookSignatureException::class)
+    fun handleInvalidSignature(ex: InvalidWebhookSignatureException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Invalid webhook signature"))
+    }
+
+    @ExceptionHandler(SubscriptionStateException::class)
+    fun handleStateException(ex: SubscriptionStateException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(ErrorResponse(ex.message ?: "Invalid subscription state transition"))
+    }
+
+    @ExceptionHandler(StripeException::class)
+    fun handleStripeException(ex: StripeException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+            .body(ErrorResponse(ex.message ?: "Stripe service error"))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/config/StripeProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/config/StripeProperties.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.subscription.internal.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fitify.stripe")
+internal data class StripeProperties(
+    val secretKey: String,
+    val webhookSecret: String,
+    val successUrl: String,
+    val cancelUrl: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookController.kt
@@ -1,0 +1,98 @@
+package com.nickdferrara.fitify.subscription.internal.controller
+
+import com.nickdferrara.fitify.subscription.internal.config.StripeProperties
+import com.nickdferrara.fitify.subscription.internal.exception.InvalidWebhookSignatureException
+import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import com.stripe.model.Event
+import com.stripe.model.Invoice
+import com.stripe.net.Webhook
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/webhooks")
+internal class StripeWebhookController(
+    private val subscriptionService: SubscriptionService,
+    private val stripeProperties: StripeProperties,
+) {
+
+    private val logger = LoggerFactory.getLogger(StripeWebhookController::class.java)
+
+    @PostMapping("/stripe")
+    fun handleStripeWebhook(
+        @RequestBody payload: String,
+        @RequestHeader("Stripe-Signature") sigHeader: String,
+    ): ResponseEntity<Void> {
+        val event: Event = try {
+            Webhook.constructEvent(payload, sigHeader, stripeProperties.webhookSecret)
+        } catch (e: Exception) {
+            throw InvalidWebhookSignatureException("Invalid Stripe webhook signature")
+        }
+
+        logger.debug("Received Stripe event: {}", event.type)
+
+        when (event.type) {
+            "customer.subscription.created" -> {
+                val stripeObject = event.dataObjectDeserializer.`object`.orElse(null)
+                if (stripeObject is com.stripe.model.Subscription) {
+                    subscriptionService.handleSubscriptionCreated(
+                        stripeSubscriptionId = stripeObject.id,
+                        customerId = stripeObject.customer,
+                        metadata = stripeObject.metadata ?: emptyMap(),
+                    )
+                }
+            }
+            "invoice.paid" -> {
+                val stripeObject = event.dataObjectDeserializer.`object`.orElse(null)
+                if (stripeObject is Invoice) {
+                    val subscriptionId = stripeObject.subscription
+                    if (subscriptionId != null) {
+                        subscriptionService.handleSubscriptionRenewed(
+                            stripeSubscriptionId = subscriptionId,
+                            amountPaid = stripeObject.amountPaid,
+                            paymentIntentId = stripeObject.paymentIntent,
+                        )
+                    }
+                }
+            }
+            "invoice.payment_failed" -> {
+                val stripeObject = event.dataObjectDeserializer.`object`.orElse(null)
+                if (stripeObject is Invoice) {
+                    val subscriptionId = stripeObject.subscription
+                    if (subscriptionId != null) {
+                        subscriptionService.handlePaymentFailed(
+                            stripeSubscriptionId = subscriptionId,
+                            paymentIntentId = stripeObject.paymentIntent,
+                        )
+                    }
+                }
+            }
+            "customer.subscription.deleted" -> {
+                val stripeObject = event.dataObjectDeserializer.`object`.orElse(null)
+                if (stripeObject is com.stripe.model.Subscription) {
+                    subscriptionService.handleSubscriptionExpired(stripeObject.id)
+                }
+            }
+            "customer.subscription.updated" -> {
+                val stripeObject = event.dataObjectDeserializer.`object`.orElse(null)
+                if (stripeObject is com.stripe.model.Subscription) {
+                    if (stripeObject.status == "active") {
+                        subscriptionService.handleSubscriptionRenewed(
+                            stripeSubscriptionId = stripeObject.id,
+                            amountPaid = 0,
+                            paymentIntentId = null,
+                        )
+                    }
+                }
+            }
+            else -> logger.debug("Unhandled Stripe event type: {}", event.type)
+        }
+
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionController.kt
@@ -1,0 +1,72 @@
+package com.nickdferrara.fitify.subscription.internal.controller
+
+import com.nickdferrara.fitify.subscription.internal.dtos.request.ChangePlanRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.request.CheckoutRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.response.BillingPortalResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.CheckoutResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionPlanResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionResponse
+import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/subscriptions")
+internal class SubscriptionController(
+    private val subscriptionService: SubscriptionService,
+) {
+
+    @GetMapping("/plans")
+    fun getAvailablePlans(): ResponseEntity<List<SubscriptionPlanResponse>> {
+        return ResponseEntity.ok(subscriptionService.getAvailablePlans())
+    }
+
+    @PostMapping("/checkout")
+    fun createCheckoutSession(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: CheckoutRequest,
+    ): ResponseEntity<CheckoutResponse> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(subscriptionService.createCheckoutSession(userId, request))
+    }
+
+    @GetMapping("/me")
+    fun getCurrentSubscription(
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<SubscriptionResponse> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(subscriptionService.getCurrentSubscription(userId))
+    }
+
+    @PostMapping("/me/cancel")
+    fun cancelSubscription(
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<SubscriptionResponse> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(subscriptionService.cancelSubscription(userId))
+    }
+
+    @PostMapping("/me/change-plan")
+    fun changePlan(
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestBody request: ChangePlanRequest,
+    ): ResponseEntity<CheckoutResponse> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(subscriptionService.changePlan(userId, request))
+    }
+
+    @PostMapping("/me/billing-portal")
+    fun createBillingPortalSession(
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<BillingPortalResponse> {
+        val userId = UUID.fromString(jwt.subject)
+        return ResponseEntity.ok(subscriptionService.createBillingPortalSession(userId))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/AnnualPlanDiscount.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/AnnualPlanDiscount.kt
@@ -1,0 +1,20 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import com.nickdferrara.fitify.subscription.internal.entities.PlanType
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+internal class AnnualPlanDiscount : DiscountCalculator {
+
+    override val strategyType: String = "ANNUAL_PLAN"
+
+    override fun applies(context: DiscountContext, strategy: DiscountStrategy): Boolean {
+        return context.planType == PlanType.ANNUAL
+    }
+
+    override fun calculate(context: DiscountContext, strategy: DiscountStrategy): BigDecimal {
+        return strategy.value
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountCalculator.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountCalculator.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import java.math.BigDecimal
+
+internal interface DiscountCalculator {
+    val strategyType: String
+    fun applies(context: DiscountContext, strategy: DiscountStrategy): Boolean
+    fun calculate(context: DiscountContext, strategy: DiscountStrategy): BigDecimal
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountContext.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountContext.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.PlanType
+import java.math.BigDecimal
+import java.util.UUID
+
+internal data class DiscountContext(
+    val userId: UUID,
+    val planType: PlanType,
+    val basePrice: BigDecimal,
+    val promotionalCode: String? = null,
+    val subscriptionMonths: Long = 0,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountStrategyResolver.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/DiscountStrategyResolver.kt
@@ -1,0 +1,28 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.repository.DiscountStrategyRepository
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+internal class DiscountStrategyResolver(
+    private val discountStrategyRepository: DiscountStrategyRepository,
+    private val calculators: List<DiscountCalculator>,
+) {
+
+    fun resolveDiscount(context: DiscountContext): BigDecimal {
+        val strategies = discountStrategyRepository.findByActiveTrueOrderByPriorityAsc()
+        val calculatorsByType = calculators.associateBy { it.strategyType }
+
+        var totalDiscount = BigDecimal.ZERO
+
+        for (strategy in strategies) {
+            val calculator = calculatorsByType[strategy.strategyType] ?: continue
+            if (calculator.applies(context, strategy)) {
+                totalDiscount = totalDiscount.add(calculator.calculate(context, strategy))
+            }
+        }
+
+        return totalDiscount.min(context.basePrice)
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/LoyaltyTierDiscount.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/LoyaltyTierDiscount.kt
@@ -1,0 +1,20 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+internal class LoyaltyTierDiscount : DiscountCalculator {
+
+    override val strategyType: String = "LOYALTY_TIER"
+
+    override fun applies(context: DiscountContext, strategy: DiscountStrategy): Boolean {
+        val minMonths = (strategy.conditions["min_months"] as? Number)?.toLong() ?: return false
+        return context.subscriptionMonths >= minMonths
+    }
+
+    override fun calculate(context: DiscountContext, strategy: DiscountStrategy): BigDecimal {
+        return strategy.value
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/PromotionalCodeDiscount.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/PromotionalCodeDiscount.kt
@@ -1,0 +1,21 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+internal class PromotionalCodeDiscount : DiscountCalculator {
+
+    override val strategyType: String = "PROMOTIONAL_CODE"
+
+    override fun applies(context: DiscountContext, strategy: DiscountStrategy): Boolean {
+        val validCodes = strategy.conditions["codes"]
+        if (validCodes !is List<*> || context.promotionalCode == null) return false
+        return validCodes.contains(context.promotionalCode)
+    }
+
+    override fun calculate(context: DiscountContext, strategy: DiscountStrategy): BigDecimal {
+        return strategy.value
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/SeasonalCampaignDiscount.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/discount/SeasonalCampaignDiscount.kt
@@ -1,0 +1,23 @@
+package com.nickdferrara.fitify.subscription.internal.discount
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Component
+internal class SeasonalCampaignDiscount : DiscountCalculator {
+
+    override val strategyType: String = "SEASONAL_CAMPAIGN"
+
+    override fun applies(context: DiscountContext, strategy: DiscountStrategy): Boolean {
+        val startDate = (strategy.conditions["start_date"] as? String)?.let { LocalDate.parse(it) } ?: return false
+        val endDate = (strategy.conditions["end_date"] as? String)?.let { LocalDate.parse(it) } ?: return false
+        val today = LocalDate.now()
+        return !today.isBefore(startDate) && !today.isAfter(endDate)
+    }
+
+    override fun calculate(context: DiscountContext, strategy: DiscountStrategy): BigDecimal {
+        return strategy.value
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/request/ChangePlanRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/request/ChangePlanRequest.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.request
+
+import java.util.UUID
+
+internal data class ChangePlanRequest(
+    val newPlanId: UUID,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/request/CheckoutRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/request/CheckoutRequest.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.request
+
+import java.util.UUID
+
+internal data class CheckoutRequest(
+    val planId: UUID,
+    val promotionalCode: String? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/BillingPortalResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/BillingPortalResponse.kt
@@ -1,0 +1,5 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.response
+
+internal data class BillingPortalResponse(
+    val url: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/CheckoutResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/CheckoutResponse.kt
@@ -1,0 +1,6 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.response
+
+internal data class CheckoutResponse(
+    val sessionId: String,
+    val url: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/ErrorResponse.kt
@@ -1,0 +1,3 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.response
+
+internal data class ErrorResponse(val message: String)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/SubscriptionPlanResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/SubscriptionPlanResponse.kt
@@ -1,0 +1,19 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.response
+
+import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionPlan
+import java.math.BigDecimal
+import java.util.UUID
+
+internal data class SubscriptionPlanResponse(
+    val id: UUID,
+    val name: String,
+    val planType: String,
+    val basePrice: BigDecimal,
+)
+
+internal fun SubscriptionPlan.toResponse() = SubscriptionPlanResponse(
+    id = id!!,
+    name = name,
+    planType = planType.name,
+    basePrice = basePrice,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/SubscriptionResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/dtos/response/SubscriptionResponse.kt
@@ -1,0 +1,27 @@
+package com.nickdferrara.fitify.subscription.internal.dtos.response
+
+import com.nickdferrara.fitify.subscription.internal.entities.Subscription
+import java.time.Instant
+import java.util.UUID
+
+internal data class SubscriptionResponse(
+    val id: UUID,
+    val userId: UUID,
+    val planType: String,
+    val status: String,
+    val currentPeriodStart: Instant?,
+    val currentPeriodEnd: Instant?,
+    val expiresAt: Instant?,
+    val createdAt: Instant?,
+)
+
+internal fun Subscription.toResponse() = SubscriptionResponse(
+    id = id!!,
+    userId = userId,
+    planType = planType.name,
+    status = status.name,
+    currentPeriodStart = currentPeriodStart,
+    currentPeriodEnd = currentPeriodEnd,
+    expiresAt = expiresAt,
+    createdAt = createdAt,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/DiscountStrategy.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/DiscountStrategy.kt
@@ -1,0 +1,35 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.math.BigDecimal
+import java.util.UUID
+
+@Entity
+@Table(name = "discount_strategies")
+internal class DiscountStrategy(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "strategy_type", nullable = false)
+    var strategyType: String,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    var value: BigDecimal,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    var conditions: Map<String, Any> = emptyMap(),
+
+    var priority: Int = 0,
+
+    var active: Boolean = true,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/PaymentHistory.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/PaymentHistory.kt
@@ -1,0 +1,47 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "payment_history")
+internal class PaymentHistory(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subscription_id", nullable = false)
+    val subscription: Subscription,
+
+    @Column(name = "stripe_payment_intent_id")
+    var stripePaymentIntentId: String? = null,
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    var amount: BigDecimal,
+
+    @Column(nullable = false, length = 3)
+    var currency: String = "usd",
+
+    @Column(nullable = false)
+    var status: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/PlanType.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/PlanType.kt
@@ -1,0 +1,6 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+internal enum class PlanType {
+    MONTHLY,
+    ANNUAL,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/Subscription.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/Subscription.kt
@@ -1,0 +1,49 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "subscriptions")
+internal class Subscription(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plan_type", nullable = false)
+    var planType: PlanType,
+
+    @Column(name = "stripe_subscription_id", unique = true)
+    var stripeSubscriptionId: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: SubscriptionStatus = SubscriptionStatus.ACTIVE,
+
+    @Column(name = "current_period_start")
+    var currentPeriodStart: Instant? = null,
+
+    @Column(name = "current_period_end")
+    var currentPeriodEnd: Instant? = null,
+
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/SubscriptionPlan.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/SubscriptionPlan.kt
@@ -1,0 +1,35 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.math.BigDecimal
+import java.util.UUID
+
+@Entity
+@Table(name = "subscription_plans")
+internal class SubscriptionPlan(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    var name: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plan_type", nullable = false)
+    var planType: PlanType,
+
+    @Column(name = "base_price", nullable = false, precision = 10, scale = 2)
+    var basePrice: BigDecimal,
+
+    @Column(name = "stripe_price_id", nullable = false)
+    var stripePriceId: String,
+
+    var active: Boolean = true,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/SubscriptionStatus.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/entities/SubscriptionStatus.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.subscription.internal.entities
+
+internal enum class SubscriptionStatus {
+    ACTIVE,
+    CANCELLING,
+    PAST_DUE,
+    EXPIRED,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/exception/SubscriptionExceptions.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/exception/SubscriptionExceptions.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.subscription.internal.exception
+
+internal class SubscriptionNotFoundException(message: String) : RuntimeException(message)
+
+internal class SubscriptionPlanNotFoundException(message: String) : RuntimeException(message)
+
+internal class ActiveSubscriptionExistsException(message: String) : RuntimeException(message)
+
+internal class StripeException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+internal class InvalidWebhookSignatureException(message: String) : RuntimeException(message)
+
+internal class SubscriptionStateException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/AnnualSubscriptionLifecycle.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/AnnualSubscriptionLifecycle.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.subscription.internal.lifecycle
+
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+@Component
+internal class AnnualSubscriptionLifecycle : SubscriptionLifecycleTemplate() {
+
+    override fun calculateExpiresAt(periodEnd: Instant): Instant {
+        return periodEnd.plus(Duration.ofDays(7))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/MonthlySubscriptionLifecycle.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/MonthlySubscriptionLifecycle.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.subscription.internal.lifecycle
+
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+@Component
+internal class MonthlySubscriptionLifecycle : SubscriptionLifecycleTemplate() {
+
+    override fun calculateExpiresAt(periodEnd: Instant): Instant {
+        return periodEnd.plus(Duration.ofDays(3))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/SubscriptionLifecycleTemplate.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/lifecycle/SubscriptionLifecycleTemplate.kt
@@ -1,0 +1,67 @@
+package com.nickdferrara.fitify.subscription.internal.lifecycle
+
+import com.nickdferrara.fitify.subscription.internal.entities.Subscription
+import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionStatus
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionStateException
+import java.time.Instant
+
+internal abstract class SubscriptionLifecycleTemplate {
+
+    fun activate(subscription: Subscription, periodStart: Instant, periodEnd: Instant): Subscription {
+        validateActivation(subscription)
+        subscription.status = SubscriptionStatus.ACTIVE
+        subscription.currentPeriodStart = periodStart
+        subscription.currentPeriodEnd = periodEnd
+        subscription.expiresAt = calculateExpiresAt(periodEnd)
+        onActivated(subscription)
+        return subscription
+    }
+
+    fun renew(subscription: Subscription, newPeriodStart: Instant, newPeriodEnd: Instant): Subscription {
+        validateRenewal(subscription)
+        subscription.status = SubscriptionStatus.ACTIVE
+        subscription.currentPeriodStart = newPeriodStart
+        subscription.currentPeriodEnd = newPeriodEnd
+        subscription.expiresAt = calculateExpiresAt(newPeriodEnd)
+        onRenewed(subscription)
+        return subscription
+    }
+
+    fun cancel(subscription: Subscription): Subscription {
+        validateCancellation(subscription)
+        subscription.status = SubscriptionStatus.CANCELLING
+        onCancelled(subscription)
+        return subscription
+    }
+
+    fun expire(subscription: Subscription): Subscription {
+        subscription.status = SubscriptionStatus.EXPIRED
+        onExpired(subscription)
+        return subscription
+    }
+
+    protected abstract fun calculateExpiresAt(periodEnd: Instant): Instant
+
+    protected open fun validateActivation(subscription: Subscription) {
+        if (subscription.status == SubscriptionStatus.ACTIVE) {
+            throw SubscriptionStateException("Subscription is already active")
+        }
+    }
+
+    protected open fun validateRenewal(subscription: Subscription) {
+        if (subscription.status == SubscriptionStatus.EXPIRED) {
+            throw SubscriptionStateException("Cannot renew an expired subscription")
+        }
+    }
+
+    protected open fun validateCancellation(subscription: Subscription) {
+        if (subscription.status != SubscriptionStatus.ACTIVE) {
+            throw SubscriptionStateException("Only active subscriptions can be cancelled")
+        }
+    }
+
+    protected open fun onActivated(subscription: Subscription) {}
+    protected open fun onRenewed(subscription: Subscription) {}
+    protected open fun onCancelled(subscription: Subscription) {}
+    protected open fun onExpired(subscription: Subscription) {}
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/DiscountStrategyRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/DiscountStrategyRepository.kt
@@ -1,0 +1,9 @@
+package com.nickdferrara.fitify.subscription.internal.repository
+
+import com.nickdferrara.fitify.subscription.internal.entities.DiscountStrategy
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface DiscountStrategyRepository : JpaRepository<DiscountStrategy, UUID> {
+    fun findByActiveTrueOrderByPriorityAsc(): List<DiscountStrategy>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/PaymentHistoryRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/PaymentHistoryRepository.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.subscription.internal.repository
+
+import com.nickdferrara.fitify.subscription.internal.entities.PaymentHistory
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface PaymentHistoryRepository : JpaRepository<PaymentHistory, UUID> {
+    fun findBySubscriptionId(subscriptionId: UUID): List<PaymentHistory>
+    fun findByUserId(userId: UUID): List<PaymentHistory>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionPlanRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionPlanRepository.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.subscription.internal.repository
+
+import com.nickdferrara.fitify.subscription.internal.entities.PlanType
+import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionPlan
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface SubscriptionPlanRepository : JpaRepository<SubscriptionPlan, UUID> {
+    fun findByActiveTrue(): List<SubscriptionPlan>
+    fun findByPlanTypeAndActiveTrue(planType: PlanType): SubscriptionPlan?
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionRepository.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.subscription.internal.repository
+
+import com.nickdferrara.fitify.subscription.internal.entities.Subscription
+import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface SubscriptionRepository : JpaRepository<Subscription, UUID> {
+    fun findByUserId(userId: UUID): List<Subscription>
+    fun findByStripeSubscriptionId(stripeSubscriptionId: String): Subscription?
+    fun findByUserIdAndStatusIn(userId: UUID, statuses: List<SubscriptionStatus>): Subscription?
+    fun existsByUserIdAndStatusIn(userId: UUID, statuses: List<SubscriptionStatus>): Boolean
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionEventListener.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.subscription.internal.service
+
+import org.springframework.stereotype.Component
+
+@Component
+internal class SubscriptionEventListener {
+    // Placeholder for consuming events from other modules (e.g., BusinessRuleUpdatedEvent from admin)
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionService.kt
@@ -1,0 +1,329 @@
+package com.nickdferrara.fitify.subscription.internal.service
+
+import com.nickdferrara.fitify.subscription.SubscriptionApi
+import com.nickdferrara.fitify.subscription.SubscriptionCancelledEvent
+import com.nickdferrara.fitify.subscription.SubscriptionCreatedEvent
+import com.nickdferrara.fitify.subscription.SubscriptionExpiredEvent
+import com.nickdferrara.fitify.subscription.SubscriptionRenewedEvent
+import com.nickdferrara.fitify.subscription.SubscriptionSummary
+import com.nickdferrara.fitify.subscription.internal.config.StripeProperties
+import com.nickdferrara.fitify.subscription.internal.discount.DiscountContext
+import com.nickdferrara.fitify.subscription.internal.discount.DiscountStrategyResolver
+import com.nickdferrara.fitify.subscription.internal.dtos.request.ChangePlanRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.request.CheckoutRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.response.BillingPortalResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.CheckoutResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionPlanResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.toResponse
+import com.nickdferrara.fitify.subscription.internal.entities.PaymentHistory
+import com.nickdferrara.fitify.subscription.internal.entities.PlanType
+import com.nickdferrara.fitify.subscription.internal.entities.Subscription
+import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionStatus
+import com.nickdferrara.fitify.subscription.internal.exception.ActiveSubscriptionExistsException
+import com.nickdferrara.fitify.subscription.internal.exception.StripeException
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionNotFoundException
+import com.nickdferrara.fitify.subscription.internal.exception.SubscriptionPlanNotFoundException
+import com.nickdferrara.fitify.subscription.internal.lifecycle.AnnualSubscriptionLifecycle
+import com.nickdferrara.fitify.subscription.internal.lifecycle.MonthlySubscriptionLifecycle
+import com.nickdferrara.fitify.subscription.internal.lifecycle.SubscriptionLifecycleTemplate
+import com.nickdferrara.fitify.subscription.internal.repository.PaymentHistoryRepository
+import com.nickdferrara.fitify.subscription.internal.repository.SubscriptionPlanRepository
+import com.nickdferrara.fitify.subscription.internal.repository.SubscriptionRepository
+import com.stripe.Stripe
+import com.stripe.model.checkout.Session
+import com.stripe.param.billingportal.SessionCreateParams as PortalSessionCreateParams
+import com.stripe.param.checkout.SessionCreateParams
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@Service
+@EnableConfigurationProperties(StripeProperties::class)
+internal class SubscriptionService(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val subscriptionPlanRepository: SubscriptionPlanRepository,
+    private val paymentHistoryRepository: PaymentHistoryRepository,
+    private val discountStrategyResolver: DiscountStrategyResolver,
+    private val monthlyLifecycle: MonthlySubscriptionLifecycle,
+    private val annualLifecycle: AnnualSubscriptionLifecycle,
+    private val stripeProperties: StripeProperties,
+    private val eventPublisher: ApplicationEventPublisher,
+) : SubscriptionApi {
+
+    @PostConstruct
+    fun init() {
+        Stripe.apiKey = stripeProperties.secretKey
+    }
+
+    // --- SubscriptionApi (cross-module) ---
+
+    override fun findActiveSubscriptionByUserId(userId: UUID): SubscriptionSummary? {
+        val subscription = subscriptionRepository.findByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING)
+        ) ?: return null
+        return subscription.toSummary()
+    }
+
+    override fun hasActiveSubscription(userId: UUID): Boolean {
+        return subscriptionRepository.existsByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING)
+        )
+    }
+
+    // --- User-facing methods ---
+
+    fun getAvailablePlans(): List<SubscriptionPlanResponse> {
+        return subscriptionPlanRepository.findByActiveTrue().map { it.toResponse() }
+    }
+
+    fun getCurrentSubscription(userId: UUID): SubscriptionResponse {
+        val subscription = subscriptionRepository.findByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING)
+        ) ?: throw SubscriptionNotFoundException("No active subscription found for user: $userId")
+        return subscription.toResponse()
+    }
+
+    @Transactional
+    fun createCheckoutSession(userId: UUID, request: CheckoutRequest): CheckoutResponse {
+        if (hasActiveSubscription(userId)) {
+            throw ActiveSubscriptionExistsException("User already has an active subscription")
+        }
+
+        val plan = subscriptionPlanRepository.findById(request.planId)
+            .orElseThrow { SubscriptionPlanNotFoundException("Plan not found: ${request.planId}") }
+
+        try {
+            val params = SessionCreateParams.builder()
+                .setMode(SessionCreateParams.Mode.SUBSCRIPTION)
+                .setSuccessUrl(stripeProperties.successUrl)
+                .setCancelUrl(stripeProperties.cancelUrl)
+                .putMetadata("userId", userId.toString())
+                .putMetadata("planType", plan.planType.name)
+                .addLineItem(
+                    SessionCreateParams.LineItem.builder()
+                        .setPrice(plan.stripePriceId)
+                        .setQuantity(1)
+                        .build()
+                )
+                .build()
+
+            val session = Session.create(params)
+            return CheckoutResponse(
+                sessionId = session.id,
+                url = session.url,
+            )
+        } catch (e: com.stripe.exception.StripeException) {
+            throw StripeException("Failed to create checkout session", e)
+        }
+    }
+
+    @Transactional
+    fun cancelSubscription(userId: UUID): SubscriptionResponse {
+        val subscription = subscriptionRepository.findByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE)
+        ) ?: throw SubscriptionNotFoundException("No active subscription found for user: $userId")
+
+        val stripeSubId = subscription.stripeSubscriptionId
+        if (stripeSubId != null) {
+            try {
+                val stripeSub = com.stripe.model.Subscription.retrieve(stripeSubId)
+                val params = com.stripe.param.SubscriptionUpdateParams.builder()
+                    .setCancelAtPeriodEnd(true)
+                    .build()
+                stripeSub.update(params)
+            } catch (e: com.stripe.exception.StripeException) {
+                throw StripeException("Failed to cancel subscription on Stripe", e)
+            }
+        }
+
+        val lifecycle = lifecycleFor(subscription.planType)
+        lifecycle.cancel(subscription)
+        val saved = subscriptionRepository.save(subscription)
+
+        eventPublisher.publishEvent(
+            SubscriptionCancelledEvent(
+                subscriptionId = saved.id!!,
+                userId = saved.userId,
+                effectiveDate = saved.currentPeriodEnd ?: Instant.now(),
+            )
+        )
+
+        return saved.toResponse()
+    }
+
+    @Transactional
+    fun changePlan(userId: UUID, request: ChangePlanRequest): CheckoutResponse {
+        val currentSubscription = subscriptionRepository.findByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING)
+        )
+
+        if (currentSubscription?.stripeSubscriptionId != null) {
+            try {
+                val stripeSub = com.stripe.model.Subscription.retrieve(currentSubscription.stripeSubscriptionId)
+                stripeSub.cancel()
+            } catch (e: com.stripe.exception.StripeException) {
+                throw StripeException("Failed to cancel existing subscription on Stripe", e)
+            }
+            currentSubscription.status = SubscriptionStatus.EXPIRED
+            subscriptionRepository.save(currentSubscription)
+        }
+
+        return createCheckoutSession(userId, CheckoutRequest(planId = request.newPlanId))
+    }
+
+    fun createBillingPortalSession(userId: UUID): BillingPortalResponse {
+        val subscription = subscriptionRepository.findByUserIdAndStatusIn(
+            userId, listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING)
+        ) ?: throw SubscriptionNotFoundException("No active subscription found for user: $userId")
+
+        val stripeSubId = subscription.stripeSubscriptionId
+            ?: throw StripeException("No Stripe subscription linked")
+
+        try {
+            val stripeSub = com.stripe.model.Subscription.retrieve(stripeSubId)
+            val params = PortalSessionCreateParams.builder()
+                .setCustomer(stripeSub.customer)
+                .setReturnUrl(stripeProperties.successUrl)
+                .build()
+
+            val portalSession = com.stripe.model.billingportal.Session.create(params)
+            return BillingPortalResponse(url = portalSession.url)
+        } catch (e: com.stripe.exception.StripeException) {
+            throw StripeException("Failed to create billing portal session", e)
+        }
+    }
+
+    // --- Webhook handlers ---
+
+    @Transactional
+    fun handleSubscriptionCreated(stripeSubscriptionId: String, customerId: String, metadata: Map<String, String>) {
+        val userId = UUID.fromString(metadata["userId"])
+        val planType = PlanType.valueOf(metadata["planType"] ?: "MONTHLY")
+
+        try {
+            val stripeSub = com.stripe.model.Subscription.retrieve(stripeSubscriptionId)
+
+            val subscription = Subscription(
+                userId = userId,
+                planType = planType,
+                stripeSubscriptionId = stripeSubscriptionId,
+            )
+
+            val lifecycle = lifecycleFor(planType)
+            lifecycle.activate(
+                subscription,
+                Instant.ofEpochSecond(stripeSub.currentPeriodStart),
+                Instant.ofEpochSecond(stripeSub.currentPeriodEnd),
+            )
+
+            val saved = subscriptionRepository.save(subscription)
+
+            eventPublisher.publishEvent(
+                SubscriptionCreatedEvent(
+                    subscriptionId = saved.id!!,
+                    userId = saved.userId,
+                    planType = saved.planType.name,
+                    stripeSubscriptionId = stripeSubscriptionId,
+                )
+            )
+        } catch (e: com.stripe.exception.StripeException) {
+            throw StripeException("Failed to retrieve subscription from Stripe", e)
+        }
+    }
+
+    @Transactional
+    fun handleSubscriptionRenewed(stripeSubscriptionId: String, amountPaid: Long, paymentIntentId: String?) {
+        val subscription = subscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId)
+            ?: return
+
+        try {
+            val stripeSub = com.stripe.model.Subscription.retrieve(stripeSubscriptionId)
+            val lifecycle = lifecycleFor(subscription.planType)
+            lifecycle.renew(
+                subscription,
+                Instant.ofEpochSecond(stripeSub.currentPeriodStart),
+                Instant.ofEpochSecond(stripeSub.currentPeriodEnd),
+            )
+            subscriptionRepository.save(subscription)
+
+            paymentHistoryRepository.save(
+                PaymentHistory(
+                    userId = subscription.userId,
+                    subscription = subscription,
+                    stripePaymentIntentId = paymentIntentId,
+                    amount = BigDecimal.valueOf(amountPaid, 2),
+                    status = "succeeded",
+                )
+            )
+
+            eventPublisher.publishEvent(
+                SubscriptionRenewedEvent(
+                    subscriptionId = subscription.id!!,
+                    userId = subscription.userId,
+                    newPeriodEnd = subscription.currentPeriodEnd!!,
+                )
+            )
+        } catch (e: com.stripe.exception.StripeException) {
+            throw StripeException("Failed to retrieve subscription from Stripe", e)
+        }
+    }
+
+    @Transactional
+    fun handleSubscriptionExpired(stripeSubscriptionId: String) {
+        val subscription = subscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId)
+            ?: return
+
+        val lifecycle = lifecycleFor(subscription.planType)
+        lifecycle.expire(subscription)
+        subscriptionRepository.save(subscription)
+
+        eventPublisher.publishEvent(
+            SubscriptionExpiredEvent(
+                subscriptionId = subscription.id!!,
+                userId = subscription.userId,
+            )
+        )
+    }
+
+    @Transactional
+    fun handlePaymentFailed(stripeSubscriptionId: String, paymentIntentId: String?) {
+        val subscription = subscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId)
+            ?: return
+
+        subscription.status = SubscriptionStatus.PAST_DUE
+        subscriptionRepository.save(subscription)
+
+        paymentHistoryRepository.save(
+            PaymentHistory(
+                userId = subscription.userId,
+                subscription = subscription,
+                stripePaymentIntentId = paymentIntentId,
+                amount = BigDecimal.ZERO,
+                status = "failed",
+            )
+        )
+    }
+
+    // --- Helpers ---
+
+    private fun lifecycleFor(planType: PlanType): SubscriptionLifecycleTemplate {
+        return when (planType) {
+            PlanType.MONTHLY -> monthlyLifecycle
+            PlanType.ANNUAL -> annualLifecycle
+        }
+    }
+
+    private fun Subscription.toSummary() = SubscriptionSummary(
+        id = id!!,
+        userId = userId,
+        planType = planType.name,
+        status = status.name,
+        currentPeriodEnd = currentPeriodEnd,
+    )
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,11 @@ fitify:
     realm: fitify
     client-id: fitify-api
     client-secret: dev-secret
+  stripe:
+    secret-key: sk_test_dev_placeholder
+    webhook-secret: whsec_dev_placeholder
+    success-url: http://localhost:3000/subscription/success
+    cancel-url: http://localhost:3000/subscription/cancel
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,11 @@ fitify:
     realm: fitify
     client-id: fitify-api
     client-secret: change-me
+  stripe:
+    secret-key: ${STRIPE_SECRET_KEY:sk_test_placeholder}
+    webhook-secret: ${STRIPE_WEBHOOK_SECRET:whsec_placeholder}
+    success-url: ${STRIPE_SUCCESS_URL:http://localhost:3000/subscription/success}
+    cancel-url: ${STRIPE_CANCEL_URL:http://localhost:3000/subscription/cancel}
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary

- Implements the full subscription module (closes #7) with plan management, Stripe Checkout integration, subscription lifecycle (create/renew/cancel/expire), and a pluggable discount strategy engine
- Adds `SubscriptionController` (6 REST endpoints at `/api/v1/subscriptions`) and `StripeWebhookController` (`POST /api/v1/webhooks/stripe`) with signature verification
- Follows existing Spring Modulith patterns with public API (`SubscriptionApi`), domain events, and internal package encapsulation

## Details

### Domain & Entities
- `SubscriptionPlan`, `Subscription`, `DiscountStrategy`, `PaymentHistory` JPA entities
- `PlanType` (MONTHLY/ANNUAL) and `SubscriptionStatus` (ACTIVE/CANCELLING/PAST_DUE/EXPIRED) enums

### Stripe Integration
- Stripe Checkout session creation for new subscriptions
- Billing portal session creation for self-service management
- Webhook controller handling `customer.subscription.created`, `invoice.paid`, `invoice.payment_failed`, `customer.subscription.deleted`, and `customer.subscription.updated` events
- Config via `@ConfigurationProperties` under `fitify.stripe` with env-var fallbacks in `application.yml`

### Discount Strategy Engine
- Strategy pattern with `DiscountCalculator` interface and 4 implementations: `PromotionalCodeDiscount`, `LoyaltyTierDiscount`, `SeasonalCampaignDiscount`, `AnnualPlanDiscount`
- Strategies stored in DB with JSONB conditions column, resolved and summed at checkout (capped at base price)

### Lifecycle Template Method
- `SubscriptionLifecycleTemplate` abstract class with `activate()`, `renew()`, `cancel()`, `expire()` and validation hooks
- `MonthlySubscriptionLifecycle` (3-day grace period) and `AnnualSubscriptionLifecycle` (7-day grace period)

### Cross-Module API
- `SubscriptionApi` exposes `findActiveSubscriptionByUserId()` and `hasActiveSubscription()` for use by other modules
- 4 domain events published: `SubscriptionCreatedEvent`, `SubscriptionRenewedEvent`, `SubscriptionCancelledEvent`, `SubscriptionExpiredEvent`

### Security
- Added `/api/v1/webhooks/**` to `permitAll()` in `SecurityConfig.kt` so Stripe webhooks bypass JWT auth

## Test plan

- [x] `./gradlew compileKotlin` passes
- [x] `./gradlew test` passes (including ModulithStructureTest)
- [x] Start app with `docker-compose up` + `./gradlew bootRun --args='--spring.profiles.active=dev'`
- [x] Verify `GET /api/v1/subscriptions/plans` returns empty list (no plans seeded)
- [x] Verify `POST /api/v1/webhooks/stripe` returns 400 without valid signature (confirms endpoint is reachable without JWT)
- [x] Verify authenticated endpoints return 401 without JWT