### PR TITLE
feat: runtime business rule configuration for admin module

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/admin/AdminApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/AdminApi.kt
@@ -1,3 +1,7 @@
 package com.nickdferrara.fitify.admin
 
-interface AdminApi
+import java.util.UUID
+
+interface AdminApi {
+    fun getBusinessRuleValue(ruleKey: String, locationId: UUID? = null): String?
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/advices/BusinessRuleExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/advices/BusinessRuleExceptionHandler.kt
@@ -1,0 +1,26 @@
+package com.nickdferrara.fitify.admin.internal.advices
+
+import com.nickdferrara.fitify.admin.internal.controller.AdminBusinessRuleController
+import com.nickdferrara.fitify.admin.internal.dtos.response.ErrorResponse
+import com.nickdferrara.fitify.admin.internal.exceptions.BusinessRuleNotFoundException
+import com.nickdferrara.fitify.admin.internal.exceptions.InvalidBusinessRuleValueException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(assignableTypes = [AdminBusinessRuleController::class])
+internal class BusinessRuleExceptionHandler {
+
+    @ExceptionHandler(BusinessRuleNotFoundException::class)
+    fun handleBusinessRuleNotFound(ex: BusinessRuleNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Business rule not found"))
+    }
+
+    @ExceptionHandler(InvalidBusinessRuleValueException::class)
+    fun handleInvalidBusinessRuleValue(ex: InvalidBusinessRuleValueException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Invalid business rule value"))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/config/BusinessRuleInitializer.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/config/BusinessRuleInitializer.kt
@@ -1,0 +1,37 @@
+package com.nickdferrara.fitify.admin.internal.config
+
+import com.nickdferrara.fitify.admin.internal.entities.BusinessRule
+import com.nickdferrara.fitify.admin.internal.repository.BusinessRuleRepository
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+@Component
+internal class BusinessRuleInitializer(
+    private val businessRuleRepository: BusinessRuleRepository,
+) : ApplicationRunner {
+
+    override fun run(args: ApplicationArguments?) {
+        val defaults = listOf(
+            Triple("cancellation_window_hours", "24", "Hours before class start when cancellation is no longer allowed"),
+            Triple("max_waitlist_size", "20", "Maximum number of users on a class waitlist"),
+            Triple("password_reset_token_expiry_minutes", "15", "Minutes before a password reset token expires"),
+            Triple("subscription_grace_period_days", "7", "Days after subscription expiry before access is revoked"),
+            Triple("discount_stacking_enabled", "false", "Whether multiple discounts can be applied to a single subscription"),
+            Triple("max_bookings_per_user_per_day", "3", "Maximum number of class bookings a user can make per day"),
+        )
+
+        for ((ruleKey, value, description) in defaults) {
+            if (businessRuleRepository.findByRuleKeyAndLocationIdIsNull(ruleKey) == null) {
+                businessRuleRepository.save(
+                    BusinessRule(
+                        ruleKey = ruleKey,
+                        value = value,
+                        description = description,
+                        updatedBy = "system",
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleController.kt
@@ -1,0 +1,38 @@
+package com.nickdferrara.fitify.admin.internal.controller
+
+import com.nickdferrara.fitify.admin.internal.AdminService
+import com.nickdferrara.fitify.admin.internal.dtos.request.UpdateBusinessRuleRequest
+import com.nickdferrara.fitify.admin.internal.dtos.response.BusinessRuleResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/business-rules")
+@PreAuthorize("hasRole('ADMIN')")
+internal class AdminBusinessRuleController(
+    private val adminService: AdminService,
+) {
+
+    @GetMapping
+    fun listBusinessRules(): ResponseEntity<List<BusinessRuleResponse>> {
+        return ResponseEntity.ok(adminService.listBusinessRules())
+    }
+
+    @PutMapping("/{ruleKey}")
+    fun updateBusinessRule(
+        @PathVariable ruleKey: String,
+        @RequestBody request: UpdateBusinessRuleRequest,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): ResponseEntity<BusinessRuleResponse> {
+        val updatedBy = jwt.subject
+        return ResponseEntity.ok(adminService.updateBusinessRule(ruleKey, request, updatedBy))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/request/UpdateBusinessRuleRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/request/UpdateBusinessRuleRequest.kt
@@ -1,0 +1,9 @@
+package com.nickdferrara.fitify.admin.internal.dtos.request
+
+import java.util.UUID
+
+internal data class UpdateBusinessRuleRequest(
+    val value: String,
+    val description: String? = null,
+    val locationId: UUID? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/response/BusinessRuleResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/response/BusinessRuleResponse.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.fitify.admin.internal.dtos.response
+
+import com.nickdferrara.fitify.admin.internal.entities.BusinessRule
+import java.time.Instant
+import java.util.UUID
+
+internal data class BusinessRuleResponse(
+    val id: UUID,
+    val ruleKey: String,
+    val value: String,
+    val locationId: UUID?,
+    val description: String?,
+    val updatedBy: String,
+    val updatedAt: Instant?,
+)
+
+internal fun BusinessRule.toResponse() = BusinessRuleResponse(
+    id = id!!,
+    ruleKey = ruleKey,
+    value = value,
+    locationId = locationId,
+    description = description,
+    updatedBy = updatedBy,
+    updatedAt = updatedAt,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/BusinessRule.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/BusinessRule.kt
@@ -1,0 +1,42 @@
+package com.nickdferrara.fitify.admin.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "business_rules",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["rule_key", "location_id"])],
+)
+internal class BusinessRule(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "rule_key", nullable = false)
+    val ruleKey: String,
+
+    @Column(nullable = false)
+    var value: String,
+
+    @Column(name = "location_id")
+    val locationId: UUID? = null,
+
+    var description: String? = null,
+
+    @Column(name = "updated_by", nullable = false)
+    var updatedBy: String,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    val updatedAt: Instant? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/exceptions/BusinessRuleExceptions.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/exceptions/BusinessRuleExceptions.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.admin.internal.exceptions
+
+internal class BusinessRuleNotFoundException(ruleKey: String) :
+    RuntimeException("Business rule not found: $ruleKey")
+
+internal class InvalidBusinessRuleValueException(ruleKey: String, reason: String) :
+    RuntimeException("Invalid value for business rule '$ruleKey': $reason")

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/repository/BusinessRuleRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/repository/BusinessRuleRepository.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.admin.internal.repository
+
+import com.nickdferrara.fitify.admin.internal.entities.BusinessRule
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface BusinessRuleRepository : JpaRepository<BusinessRule, UUID> {
+    fun findByRuleKeyAndLocationIdIsNull(ruleKey: String): BusinessRule?
+    fun findByRuleKeyAndLocationId(ruleKey: String, locationId: UUID): BusinessRule?
+    fun findAllByOrderByRuleKeyAscLocationIdAsc(): List<BusinessRule>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingEventListener.kt
@@ -1,13 +1,32 @@
 package com.nickdferrara.fitify.scheduling.internal.service
 
+import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
-internal class SchedulingEventListener {
+internal class SchedulingEventListener(
+    private val schedulingService: SchedulingService,
+) {
 
-    // Placeholder for cross-module event handling.
-    // Future listeners:
-    // - BusinessRuleUpdatedEvent: update cancellationWindowHours, maxWaitlistSize, maxBookingsPerDay
-    // - SubscriptionExpiredEvent: prevent bookings for expired subscriptions
-    // - LocationDeactivatedEvent: cancel all future classes at deactivated location
+    private val logger = LoggerFactory.getLogger(SchedulingEventListener::class.java)
+
+    @EventListener
+    fun onBusinessRuleUpdated(event: BusinessRuleUpdatedEvent) {
+        when (event.ruleKey) {
+            "cancellation_window_hours" -> {
+                schedulingService.cancellationWindowHours = event.newValue.toLong()
+                logger.info("Updated cancellationWindowHours to {}", event.newValue)
+            }
+            "max_waitlist_size" -> {
+                schedulingService.maxWaitlistSize = event.newValue.toInt()
+                logger.info("Updated maxWaitlistSize to {}", event.newValue)
+            }
+            "max_bookings_per_user_per_day" -> {
+                schedulingService.maxBookingsPerDay = event.newValue.toInt()
+                logger.info("Updated maxBookingsPerDay to {}", event.newValue)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/BusinessRuleUpdatedEvent.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/BusinessRuleUpdatedEvent.kt
@@ -1,0 +1,10 @@
+package com.nickdferrara.fitify.shared
+
+import java.util.UUID
+
+data class BusinessRuleUpdatedEvent(
+    val ruleKey: String,
+    val newValue: String,
+    val locationId: UUID?,
+    val updatedBy: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionEventListener.kt
@@ -1,8 +1,24 @@
 package com.nickdferrara.fitify.subscription.internal.service
 
+import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 internal class SubscriptionEventListener {
-    // Placeholder for consuming events from other modules (e.g., BusinessRuleUpdatedEvent from admin)
+
+    private val logger = LoggerFactory.getLogger(SubscriptionEventListener::class.java)
+
+    @EventListener
+    fun onBusinessRuleUpdated(event: BusinessRuleUpdatedEvent) {
+        when (event.ruleKey) {
+            "subscription_grace_period_days" -> {
+                logger.info("Business rule updated: subscription_grace_period_days = {}", event.newValue)
+            }
+            "discount_stacking_enabled" -> {
+                logger.info("Business rule updated: discount_stacking_enabled = {}", event.newValue)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add runtime-configurable business rules with CRUD endpoints (`GET /api/v1/admin/business-rules`, `PUT /api/v1/admin/business-rules/{ruleKey}`) so admins can modify rules without redeployment
- Support per-location overrides that take precedence over global defaults, with fallback resolution logic
- Publish `BusinessRuleUpdatedEvent` on changes, consumed by scheduling and subscription event listeners to update in-memory settings (e.g., `cancellationWindowHours`, `maxWaitlistSize`, `maxBookingsPerDay`)
- Seed 6 default global rules on startup via `BusinessRuleInitializer` (idempotent)

## New files

- `BusinessRuleUpdatedEvent.kt` — cross-module event in `shared` package
- `BusinessRule.kt` — JPA entity with unique constraint on `(rule_key, location_id)`
- `BusinessRuleRepository.kt` — Spring Data repo with global/per-location finders
- `UpdateBusinessRuleRequest.kt`, `BusinessRuleResponse.kt` — request/response DTOs
- `BusinessRuleExceptions.kt` — `BusinessRuleNotFoundException`, `InvalidBusinessRuleValueException`
- `AdminBusinessRuleController.kt` — REST controller secured with `@PreAuthorize("hasRole('ADMIN')")`
- `BusinessRuleExceptionHandler.kt` — scoped exception handler (404/400)
- `BusinessRuleInitializer.kt` — `ApplicationRunner` that seeds default rules

## Modified files

- `AdminApi.kt` — added `getBusinessRuleValue()` for cross-module queries
- `AdminService.kt` — implemented rule resolution, listing, and upsert with event publishing
- `SchedulingEventListener.kt` — consumes `BusinessRuleUpdatedEvent` to update mutable scheduling vars
- `SubscriptionEventListener.kt` — consumes `BusinessRuleUpdatedEvent` with logging hooks
- `AdminServiceTest.kt` — 7 new tests for business rule operations

## Test plan

- [x] `./gradlew build` compiles successfully
- [x] All 142 tests pass (including modulith structure verification)
- [x] Manual verification: Hibernate auto-creates `business_rules` table, initializer seeds defaults, endpoints respond correctly