### PR TITLE
feat: add metrics & analytics dashboard to admin module

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/advices/MetricsExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/advices/MetricsExceptionHandler.kt
@@ -1,0 +1,20 @@
+package com.nickdferrara.fitify.admin.internal.advices
+
+import com.nickdferrara.fitify.admin.internal.controller.AdminLocationMetricsController
+import com.nickdferrara.fitify.admin.internal.controller.AdminMetricsController
+import com.nickdferrara.fitify.admin.internal.dtos.response.ErrorResponse
+import com.nickdferrara.fitify.admin.internal.exceptions.InvalidMetricsQueryException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(assignableTypes = [AdminMetricsController::class, AdminLocationMetricsController::class])
+internal class MetricsExceptionHandler {
+
+    @ExceptionHandler(InvalidMetricsQueryException::class)
+    fun handleInvalidMetricsQuery(ex: InvalidMetricsQueryException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(ex.message ?: "Invalid metrics query"))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/config/MetricsSchedulingConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/config/MetricsSchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.admin.internal.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+internal class MetricsSchedulingConfig

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
@@ -1,0 +1,84 @@
+package com.nickdferrara.fitify.admin.internal.controller
+
+import com.nickdferrara.fitify.admin.internal.dtos.response.MetricResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.OverviewResponse
+import com.nickdferrara.fitify.admin.internal.entities.Granularity
+import com.nickdferrara.fitify.admin.internal.service.MetricsService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/admin/metrics")
+@PreAuthorize("hasRole('ADMIN')")
+internal class AdminMetricsController(
+    private val metricsService: MetricsService,
+) {
+
+    @GetMapping("/signups")
+    fun getSignups(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam(defaultValue = "DAILY") granularity: Granularity,
+        @RequestParam(required = false) locationId: UUID?,
+    ): ResponseEntity<MetricResponse> {
+        return ResponseEntity.ok(metricsService.getSignups(from, to, granularity, locationId))
+    }
+
+    @GetMapping("/cancellations")
+    fun getCancellations(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam(defaultValue = "DAILY") granularity: Granularity,
+        @RequestParam(required = false) locationId: UUID?,
+    ): ResponseEntity<MetricResponse> {
+        return ResponseEntity.ok(metricsService.getCancellations(from, to, granularity, locationId))
+    }
+
+    @GetMapping("/revenue")
+    fun getRevenue(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam(defaultValue = "DAILY") granularity: Granularity,
+        @RequestParam(required = false) locationId: UUID?,
+    ): ResponseEntity<MetricResponse> {
+        return ResponseEntity.ok(metricsService.getRevenue(from, to, granularity, locationId))
+    }
+
+    @GetMapping("/overview")
+    fun getOverview(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+        @RequestParam(required = false) locationId: UUID?,
+    ): ResponseEntity<OverviewResponse> {
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(30)
+        return ResponseEntity.ok(metricsService.getOverview(effectiveFrom, effectiveTo, locationId))
+    }
+}
+
+@RestController
+@RequestMapping("/api/v1/admin/locations/{locationId}/metrics")
+@PreAuthorize("hasRole('ADMIN')")
+internal class AdminLocationMetricsController(
+    private val metricsService: MetricsService,
+) {
+
+    @GetMapping("/overview")
+    fun getLocationOverview(
+        @PathVariable locationId: UUID,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+    ): ResponseEntity<OverviewResponse> {
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(30)
+        return ResponseEntity.ok(metricsService.getOverview(effectiveFrom, effectiveTo, locationId))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/response/MetricsResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/dtos/response/MetricsResponse.kt
@@ -1,0 +1,42 @@
+package com.nickdferrara.fitify.admin.internal.dtos.response
+
+import com.nickdferrara.fitify.admin.internal.entities.Granularity
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+internal data class MetricDataPoint(
+    val date: LocalDate,
+    val value: BigDecimal,
+    val dimensions: Map<String, String> = emptyMap(),
+)
+
+internal data class TrendComparison(
+    val currentPeriodTotal: BigDecimal,
+    val previousPeriodTotal: BigDecimal,
+    val changeAbsolute: BigDecimal,
+    val changePercent: BigDecimal?,
+)
+
+internal data class MetricResponse(
+    val metricType: MetricType,
+    val granularity: Granularity,
+    val from: LocalDate,
+    val to: LocalDate,
+    val dataPoints: List<MetricDataPoint>,
+    val trend: TrendComparison?,
+)
+
+internal data class MetricSummary(
+    val metricType: MetricType,
+    val currentValue: BigDecimal,
+    val trend: TrendComparison?,
+)
+
+internal data class OverviewResponse(
+    val from: LocalDate,
+    val to: LocalDate,
+    val locationId: UUID?,
+    val metrics: List<MetricSummary>,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/Granularity.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/Granularity.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.admin.internal.entities
+
+internal enum class Granularity {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/MetricType.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/MetricType.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.admin.internal.entities
+
+internal enum class MetricType {
+    SIGNUPS,
+    CANCELLATIONS,
+    REVENUE,
+    ACTIVE_SUBSCRIPTIONS,
+    CLASS_UTILIZATION,
+    WAITLIST_CONVERSION,
+    CHURN_RATE,
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/MetricsSnapshot.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/entities/MetricsSnapshot.kt
@@ -1,0 +1,41 @@
+package com.nickdferrara.fitify.admin.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "metrics_snapshots")
+internal class MetricsSnapshot(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_type", nullable = false)
+    val metricType: MetricType,
+
+    @Column(name = "location_id")
+    val locationId: UUID? = null,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    var dimensions: Map<String, String> = emptyMap(),
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    var value: BigDecimal = BigDecimal.ZERO,
+
+    @Column(name = "snapshot_date", nullable = false)
+    val snapshotDate: LocalDate,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/exceptions/MetricsExceptions.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/exceptions/MetricsExceptions.kt
@@ -1,0 +1,4 @@
+package com.nickdferrara.fitify.admin.internal.exceptions
+
+internal class InvalidMetricsQueryException(reason: String) :
+    RuntimeException("Invalid metrics query: $reason")

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/repository/MetricsSnapshotRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/repository/MetricsSnapshotRepository.kt
@@ -1,0 +1,34 @@
+package com.nickdferrara.fitify.admin.internal.repository
+
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+import java.util.UUID
+
+internal interface MetricsSnapshotRepository : JpaRepository<MetricsSnapshot, UUID> {
+
+    fun findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(
+        metricType: MetricType,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<MetricsSnapshot>
+
+    fun findByMetricTypeAndSnapshotDateBetweenAndLocationId(
+        metricType: MetricType,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        locationId: UUID,
+    ): List<MetricsSnapshot>
+
+    fun findByMetricTypeAndSnapshotDateAndLocationIdIsNull(
+        metricType: MetricType,
+        snapshotDate: LocalDate,
+    ): List<MetricsSnapshot>
+
+    fun findByMetricTypeAndSnapshotDateAndLocationId(
+        metricType: MetricType,
+        snapshotDate: LocalDate,
+        locationId: UUID,
+    ): List<MetricsSnapshot>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsAggregationScheduler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsAggregationScheduler.kt
@@ -1,0 +1,190 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.subscription.SubscriptionApi
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Component
+internal class MetricsAggregationScheduler(
+    private val metricsSnapshotRepository: MetricsSnapshotRepository,
+    private val subscriptionApi: SubscriptionApi,
+    private val schedulingApi: SchedulingApi,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "\${fitify.metrics.aggregation-cron:0 0 2 * * *}")
+    @Transactional
+    fun runDailyAggregation() {
+        log.info("Starting daily metrics aggregation")
+        val yesterday = LocalDate.now().minusDays(1)
+        aggregateActiveSubscriptions(yesterday)
+        aggregateRevenue(yesterday)
+        aggregateClassUtilization(yesterday)
+        aggregateChurnRate(yesterday)
+        log.info("Daily metrics aggregation completed")
+    }
+
+    internal fun aggregateActiveSubscriptions(date: LocalDate) {
+        val countsByPlanType = subscriptionApi.countActiveSubscriptionsByPlanType()
+        var total = 0L
+
+        for ((planType, count) in countsByPlanType) {
+            upsertSnapshot(
+                metricType = MetricType.ACTIVE_SUBSCRIPTIONS,
+                date = date,
+                locationId = null,
+                dimensions = mapOf("plan_type" to planType),
+                value = BigDecimal.valueOf(count),
+            )
+            total += count
+        }
+
+        upsertSnapshot(
+            metricType = MetricType.ACTIVE_SUBSCRIPTIONS,
+            date = date,
+            locationId = null,
+            dimensions = emptyMap(),
+            value = BigDecimal.valueOf(total),
+        )
+    }
+
+    internal fun aggregateRevenue(date: LocalDate) {
+        val dayStart = date.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val dayEnd = date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+
+        val revenueByPlanType = subscriptionApi.sumRevenueBetweenByPlanType(dayStart, dayEnd)
+        var total = BigDecimal.ZERO
+
+        for ((planType, revenue) in revenueByPlanType) {
+            upsertSnapshot(
+                metricType = MetricType.REVENUE,
+                date = date,
+                locationId = null,
+                dimensions = mapOf("plan_type" to planType),
+                value = revenue,
+            )
+            total = total.add(revenue)
+        }
+
+        upsertSnapshot(
+            metricType = MetricType.REVENUE,
+            date = date,
+            locationId = null,
+            dimensions = emptyMap(),
+            value = total,
+        )
+    }
+
+    internal fun aggregateClassUtilization(date: LocalDate) {
+        val dayStart = date.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val dayEnd = date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+
+        val utilizations = schedulingApi.getClassUtilizationByDateRange(dayStart, dayEnd)
+        val byLocation = utilizations.groupBy { it.locationId }
+
+        for ((locationId, classes) in byLocation) {
+            val avgUtilization = if (classes.isEmpty()) {
+                BigDecimal.ZERO
+            } else {
+                val totalUtilization = classes.sumOf { cls ->
+                    if (cls.capacity > 0) {
+                        cls.enrolledCount.toBigDecimal()
+                            .divide(cls.capacity.toBigDecimal(), 4, RoundingMode.HALF_UP)
+                            .multiply(BigDecimal(100))
+                    } else {
+                        BigDecimal.ZERO
+                    }
+                }
+                totalUtilization.divide(classes.size.toBigDecimal(), 2, RoundingMode.HALF_UP)
+            }
+
+            upsertSnapshot(
+                metricType = MetricType.CLASS_UTILIZATION,
+                date = date,
+                locationId = locationId,
+                dimensions = emptyMap(),
+                value = avgUtilization,
+            )
+        }
+    }
+
+    internal fun aggregateChurnRate(date: LocalDate) {
+        val monthStart = date.withDayOfMonth(1)
+        if (date != monthStart) return
+
+        val previousMonthStart = monthStart.minusMonths(1)
+
+        val startInstant = previousMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val endInstant = monthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+
+        val expiredCount = subscriptionApi.countSubscriptionsExpiredBetween(startInstant, endInstant)
+        val activeAtStart = subscriptionApi.countActiveSubscriptionsAsOf(startInstant)
+
+        val churnRate = if (activeAtStart > 0) {
+            BigDecimal.valueOf(expiredCount)
+                .divide(BigDecimal.valueOf(activeAtStart), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal(100))
+        } else {
+            BigDecimal.ZERO
+        }
+
+        val previousMonthEnd = monthStart.minusDays(1)
+        upsertSnapshot(
+            metricType = MetricType.CHURN_RATE,
+            date = previousMonthEnd,
+            locationId = null,
+            dimensions = emptyMap(),
+            value = churnRate,
+        )
+    }
+
+    private fun upsertSnapshot(
+        metricType: MetricType,
+        date: LocalDate,
+        locationId: UUID?,
+        dimensions: Map<String, String>,
+        value: BigDecimal,
+    ) {
+        val existing = findSnapshot(metricType, date, locationId, dimensions)
+        if (existing != null) {
+            existing.value = value
+            metricsSnapshotRepository.save(existing)
+        } else {
+            metricsSnapshotRepository.save(
+                MetricsSnapshot(
+                    metricType = metricType,
+                    locationId = locationId,
+                    dimensions = dimensions,
+                    value = value,
+                    snapshotDate = date,
+                )
+            )
+        }
+    }
+
+    private fun findSnapshot(
+        metricType: MetricType,
+        date: LocalDate,
+        locationId: UUID?,
+        dimensions: Map<String, String>,
+    ): MetricsSnapshot? {
+        val snapshots = if (locationId != null) {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateAndLocationId(metricType, date, locationId)
+        } else {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(metricType, date)
+        }
+        return snapshots.find { it.dimensions == dimensions }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsEventListener.kt
@@ -1,0 +1,122 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import com.nickdferrara.fitify.identity.UserRegisteredEvent
+import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
+import com.nickdferrara.fitify.shared.Result
+import com.nickdferrara.fitify.subscription.SubscriptionCreatedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+internal class MetricsEventListener(
+    private val metricsSnapshotRepository: MetricsSnapshotRepository,
+    private val schedulingApi: SchedulingApi,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @EventListener
+    @Transactional
+    fun onUserRegistered(event: UserRegisteredEvent) {
+        log.debug("Metrics: recording signup for user {}", event.userId)
+        incrementMetric(MetricType.SIGNUPS, locationId = null, dimensions = emptyMap())
+    }
+
+    @EventListener
+    @Transactional
+    fun onBookingCancelled(event: BookingCancelledEvent) {
+        log.debug("Metrics: recording cancellation for class {}", event.classId)
+        when (val classResult = schedulingApi.findClassById(event.classId)) {
+            is Result.Success -> {
+                val classSummary = classResult.value
+                incrementMetric(
+                    MetricType.CANCELLATIONS,
+                    locationId = classSummary.locationId,
+                    dimensions = mapOf("class_type" to classSummary.classType),
+                )
+            }
+            is Result.Failure -> {
+                log.warn("Metrics: could not find class {} for cancellation metric", event.classId)
+                incrementMetric(MetricType.CANCELLATIONS, locationId = null, dimensions = emptyMap())
+            }
+        }
+    }
+
+    @EventListener
+    @Transactional
+    fun onSubscriptionCreated(event: SubscriptionCreatedEvent) {
+        log.debug("Metrics: recording revenue for subscription {}", event.subscriptionId)
+        incrementMetric(
+            MetricType.REVENUE,
+            locationId = null,
+            dimensions = mapOf("plan_type" to event.planType),
+        )
+    }
+
+    @EventListener
+    @Transactional
+    fun onWaitlistPromoted(event: WaitlistPromotedEvent) {
+        log.debug("Metrics: recording waitlist promotion for class {}", event.classId)
+        when (val classResult = schedulingApi.findClassById(event.classId)) {
+            is Result.Success -> {
+                val classSummary = classResult.value
+                incrementMetric(
+                    MetricType.WAITLIST_CONVERSION,
+                    locationId = classSummary.locationId,
+                    dimensions = mapOf("class_type" to classSummary.classType),
+                )
+            }
+            is Result.Failure -> {
+                log.warn("Metrics: could not find class {} for waitlist conversion metric", event.classId)
+                incrementMetric(MetricType.WAITLIST_CONVERSION, locationId = null, dimensions = emptyMap())
+            }
+        }
+    }
+
+    private fun incrementMetric(
+        metricType: MetricType,
+        locationId: UUID?,
+        dimensions: Map<String, String>,
+    ) {
+        val today = LocalDate.now()
+        val existing = findSnapshot(metricType, today, locationId, dimensions)
+        if (existing != null) {
+            existing.value = existing.value.add(BigDecimal.ONE)
+            metricsSnapshotRepository.save(existing)
+        } else {
+            metricsSnapshotRepository.save(
+                MetricsSnapshot(
+                    metricType = metricType,
+                    locationId = locationId,
+                    dimensions = dimensions,
+                    value = BigDecimal.ONE,
+                    snapshotDate = today,
+                )
+            )
+        }
+    }
+
+    private fun findSnapshot(
+        metricType: MetricType,
+        date: LocalDate,
+        locationId: UUID?,
+        dimensions: Map<String, String>,
+    ): MetricsSnapshot? {
+        val snapshots = if (locationId != null) {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateAndLocationId(metricType, date, locationId)
+        } else {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(metricType, date)
+        }
+        return snapshots.find { it.dimensions == dimensions }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsService.kt
@@ -1,0 +1,206 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.dtos.response.MetricDataPoint
+import com.nickdferrara.fitify.admin.internal.dtos.response.MetricResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.MetricSummary
+import com.nickdferrara.fitify.admin.internal.dtos.response.OverviewResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.TrendComparison
+import com.nickdferrara.fitify.admin.internal.entities.Granularity
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.exceptions.InvalidMetricsQueryException
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.IsoFields
+import java.util.UUID
+
+@Service
+internal class MetricsService(
+    private val metricsSnapshotRepository: MetricsSnapshotRepository,
+) {
+
+    fun getSignups(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+        validateDateRange(from, to)
+        return getMetric(MetricType.SIGNUPS, from, to, granularity, locationId)
+    }
+
+    fun getCancellations(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+        validateDateRange(from, to)
+        return getMetric(MetricType.CANCELLATIONS, from, to, granularity, locationId)
+    }
+
+    fun getRevenue(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+        validateDateRange(from, to)
+        return getMetric(MetricType.REVENUE, from, to, granularity, locationId)
+    }
+
+    fun getOverview(from: LocalDate, to: LocalDate, locationId: UUID?): OverviewResponse {
+        validateDateRange(from, to)
+        val metricTypes = listOf(
+            MetricType.SIGNUPS,
+            MetricType.CANCELLATIONS,
+            MetricType.REVENUE,
+            MetricType.ACTIVE_SUBSCRIPTIONS,
+            MetricType.CLASS_UTILIZATION,
+            MetricType.WAITLIST_CONVERSION,
+            MetricType.CHURN_RATE,
+        )
+
+        val summaries = metricTypes.map { metricType ->
+            val snapshots = fetchSnapshots(metricType, from, to, locationId)
+            val currentValue = computeCurrentValue(metricType, snapshots)
+            val trend = computeTrend(metricType, from, to, locationId)
+            MetricSummary(
+                metricType = metricType,
+                currentValue = currentValue,
+                trend = trend,
+            )
+        }
+
+        return OverviewResponse(
+            from = from,
+            to = to,
+            locationId = locationId,
+            metrics = summaries,
+        )
+    }
+
+    private fun getMetric(
+        metricType: MetricType,
+        from: LocalDate,
+        to: LocalDate,
+        granularity: Granularity,
+        locationId: UUID?,
+    ): MetricResponse {
+        val snapshots = fetchSnapshots(metricType, from, to, locationId)
+        val dataPoints = rollup(snapshots, granularity, metricType)
+        val trend = computeTrend(metricType, from, to, locationId)
+
+        return MetricResponse(
+            metricType = metricType,
+            granularity = granularity,
+            from = from,
+            to = to,
+            dataPoints = dataPoints,
+            trend = trend,
+        )
+    }
+
+    private fun fetchSnapshots(
+        metricType: MetricType,
+        from: LocalDate,
+        to: LocalDate,
+        locationId: UUID?,
+    ): List<MetricsSnapshot> {
+        return if (locationId != null) {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateBetweenAndLocationId(
+                metricType, from, to, locationId,
+            )
+        } else {
+            metricsSnapshotRepository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(
+                metricType, from, to,
+            )
+        }
+    }
+
+    private fun rollup(
+        snapshots: List<MetricsSnapshot>,
+        granularity: Granularity,
+        metricType: MetricType,
+    ): List<MetricDataPoint> {
+        if (snapshots.isEmpty()) return emptyList()
+
+        val aggregateSnapshots = snapshots.filter { it.dimensions.isEmpty() }
+
+        return when (granularity) {
+            Granularity.DAILY -> aggregateSnapshots.map { snapshot ->
+                MetricDataPoint(date = snapshot.snapshotDate, value = snapshot.value)
+            }.sortedBy { it.date }
+
+            Granularity.WEEKLY -> aggregateSnapshots
+                .groupBy {
+                    it.snapshotDate.get(IsoFields.WEEK_BASED_YEAR) * 100 +
+                        it.snapshotDate.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)
+                }
+                .map { (_, weekSnapshots) ->
+                    val weekStart = weekSnapshots.minOf { it.snapshotDate }
+                    val value = aggregateValue(weekSnapshots, metricType)
+                    MetricDataPoint(date = weekStart, value = value)
+                }.sortedBy { it.date }
+
+            Granularity.MONTHLY -> aggregateSnapshots
+                .groupBy { it.snapshotDate.year * 100 + it.snapshotDate.monthValue }
+                .map { (_, monthSnapshots) ->
+                    val monthStart = monthSnapshots.minOf { it.snapshotDate }
+                    val value = aggregateValue(monthSnapshots, metricType)
+                    MetricDataPoint(date = monthStart, value = value)
+                }.sortedBy { it.date }
+        }
+    }
+
+    private fun aggregateValue(snapshots: List<MetricsSnapshot>, metricType: MetricType): BigDecimal {
+        return if (isPointInTimeMetric(metricType)) {
+            snapshots.maxByOrNull { it.snapshotDate }?.value ?: BigDecimal.ZERO
+        } else {
+            snapshots.fold(BigDecimal.ZERO) { acc, s -> acc.add(s.value) }
+        }
+    }
+
+    private fun computeCurrentValue(metricType: MetricType, snapshots: List<MetricsSnapshot>): BigDecimal {
+        val aggregateSnapshots = snapshots.filter { it.dimensions.isEmpty() }
+        return if (isPointInTimeMetric(metricType)) {
+            aggregateSnapshots.maxByOrNull { it.snapshotDate }?.value ?: BigDecimal.ZERO
+        } else {
+            aggregateSnapshots.fold(BigDecimal.ZERO) { acc, s -> acc.add(s.value) }
+        }
+    }
+
+    private fun computeTrend(
+        metricType: MetricType,
+        from: LocalDate,
+        to: LocalDate,
+        locationId: UUID?,
+    ): TrendComparison? {
+        val periodLength = ChronoUnit.DAYS.between(from, to) + 1
+        val previousFrom = from.minusDays(periodLength)
+        val previousTo = from.minusDays(1)
+
+        val currentSnapshots = fetchSnapshots(metricType, from, to, locationId)
+        val previousSnapshots = fetchSnapshots(metricType, previousFrom, previousTo, locationId)
+
+        val currentTotal = computeCurrentValue(metricType, currentSnapshots)
+        val previousTotal = computeCurrentValue(metricType, previousSnapshots)
+
+        val changeAbsolute = currentTotal.subtract(previousTotal)
+        val changePercent = if (previousTotal.compareTo(BigDecimal.ZERO) != 0) {
+            changeAbsolute.divide(previousTotal, 4, RoundingMode.HALF_UP).multiply(BigDecimal(100))
+        } else {
+            null
+        }
+
+        return TrendComparison(
+            currentPeriodTotal = currentTotal,
+            previousPeriodTotal = previousTotal,
+            changeAbsolute = changeAbsolute,
+            changePercent = changePercent,
+        )
+    }
+
+    private fun isPointInTimeMetric(metricType: MetricType): Boolean {
+        return metricType in listOf(
+            MetricType.ACTIVE_SUBSCRIPTIONS,
+            MetricType.CLASS_UTILIZATION,
+            MetricType.CHURN_RATE,
+        )
+    }
+
+    private fun validateDateRange(from: LocalDate, to: LocalDate) {
+        if (from.isAfter(to)) {
+            throw InvalidMetricsQueryException("'from' date must not be after 'to' date")
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/SchedulingApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/SchedulingApi.kt
@@ -62,6 +62,14 @@ data class CancelClassResult(
     val waitlistUserIds: List<UUID>,
 )
 
+data class ClassUtilizationSummary(
+    val classId: UUID,
+    val locationId: UUID,
+    val classType: String,
+    val capacity: Int,
+    val enrolledCount: Int,
+)
+
 interface SchedulingApi {
     fun findClassById(id: UUID): Result<ClassSummary, DomainError>
     fun findUpcomingClassesByLocationId(locationId: UUID): List<ClassSummary>
@@ -71,4 +79,6 @@ interface SchedulingApi {
     fun getClassDetail(classId: UUID): Result<ClassDetail, DomainError>
     fun findClassesByLocationId(locationId: UUID): List<ClassDetail>
     fun findClassesByCoachIdAndTimeRange(coachId: UUID, startTime: Instant, endTime: Instant): List<ClassSummary>
+    fun getClassUtilizationByDateRange(start: Instant, end: Instant): List<ClassUtilizationSummary>
+    fun countBookingCancellationsBetween(start: Instant, end: Instant, locationId: UUID?): Long
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/BookingRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/BookingRepository.kt
@@ -40,4 +40,21 @@ internal interface BookingRepository : JpaRepository<Booking, UUID> {
     fun countUserBookingsForDay(userId: UUID, dayStart: Instant, dayEnd: Instant): Long
 
     fun findByFitnessClassIdAndStatus(fitnessClassId: UUID, status: BookingStatus): List<Booking>
+
+    @Query(
+        """
+        SELECT COUNT(b) FROM Booking b
+        WHERE b.status = 'CANCELLED' AND b.cancelledAt BETWEEN :start AND :end
+        """
+    )
+    fun countCancellationsBetween(start: Instant, end: Instant): Long
+
+    @Query(
+        """
+        SELECT COUNT(b) FROM Booking b
+        WHERE b.status = 'CANCELLED' AND b.cancelledAt BETWEEN :start AND :end
+          AND b.fitnessClass.locationId = :locationId
+        """
+    )
+    fun countCancellationsBetweenAndLocationId(start: Instant, end: Instant, locationId: UUID): Long
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/repository/FitnessClassRepository.kt
@@ -26,4 +26,12 @@ internal interface FitnessClassRepository :
         """
     )
     fun findByCoachIdAndTimeRange(coachId: UUID, startTime: Instant, endTime: Instant): List<FitnessClass>
+
+    @Query(
+        """
+        SELECT DISTINCT fc FROM FitnessClass fc LEFT JOIN FETCH fc.bookings
+        WHERE fc.status = 'ACTIVE' AND fc.startTime >= :start AND fc.startTime < :end
+        """
+    )
+    fun findWithBookingsByDateRange(start: Instant, end: Instant): List<FitnessClass>
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/SubscriptionApi.kt
@@ -1,5 +1,6 @@
 package com.nickdferrara.fitify.subscription
 
+import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
@@ -14,4 +15,9 @@ data class SubscriptionSummary(
 interface SubscriptionApi {
     fun findActiveSubscriptionByUserId(userId: UUID): SubscriptionSummary?
     fun hasActiveSubscription(userId: UUID): Boolean
+    fun countActiveSubscriptionsByPlanType(): Map<String, Long>
+    fun countSubscriptionsExpiredBetween(start: Instant, end: Instant): Long
+    fun countActiveSubscriptionsAsOf(asOf: Instant): Long
+    fun sumRevenueBetween(start: Instant, end: Instant): BigDecimal
+    fun sumRevenueBetweenByPlanType(start: Instant, end: Instant): Map<String, BigDecimal>
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/PaymentHistoryRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/PaymentHistoryRepository.kt
@@ -2,9 +2,25 @@ package com.nickdferrara.fitify.subscription.internal.repository
 
 import com.nickdferrara.fitify.subscription.internal.entities.PaymentHistory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
 internal interface PaymentHistoryRepository : JpaRepository<PaymentHistory, UUID> {
     fun findBySubscriptionId(subscriptionId: UUID): List<PaymentHistory>
     fun findByUserId(userId: UUID): List<PaymentHistory>
+
+    @Query("SELECT COALESCE(SUM(p.amount), 0) FROM PaymentHistory p WHERE p.status = 'succeeded' AND p.createdAt BETWEEN :start AND :end")
+    fun sumRevenueBetween(start: Instant, end: Instant): BigDecimal
+
+    @Query(
+        """
+        SELECT p.subscription.planType, COALESCE(SUM(p.amount), 0)
+        FROM PaymentHistory p
+        WHERE p.status = 'succeeded' AND p.createdAt BETWEEN :start AND :end
+        GROUP BY p.subscription.planType
+        """
+    )
+    fun sumRevenueBetweenGroupByPlanType(start: Instant, end: Instant): List<Array<Any>>
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/repository/SubscriptionRepository.kt
@@ -3,6 +3,8 @@ package com.nickdferrara.fitify.subscription.internal.repository
 import com.nickdferrara.fitify.subscription.internal.entities.Subscription
 import com.nickdferrara.fitify.subscription.internal.entities.SubscriptionStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
 import java.util.UUID
 
 internal interface SubscriptionRepository : JpaRepository<Subscription, UUID> {
@@ -10,4 +12,19 @@ internal interface SubscriptionRepository : JpaRepository<Subscription, UUID> {
     fun findByStripeSubscriptionId(stripeSubscriptionId: String): Subscription?
     fun findByUserIdAndStatusIn(userId: UUID, statuses: List<SubscriptionStatus>): Subscription?
     fun existsByUserIdAndStatusIn(userId: UUID, statuses: List<SubscriptionStatus>): Boolean
+
+    @Query("SELECT s.planType, COUNT(s) FROM Subscription s WHERE s.status IN :statuses GROUP BY s.planType")
+    fun countByStatusInGroupByPlanType(statuses: List<SubscriptionStatus>): List<Array<Any>>
+
+    @Query("SELECT COUNT(s) FROM Subscription s WHERE s.status = 'EXPIRED' AND s.currentPeriodEnd BETWEEN :start AND :end")
+    fun countExpiredBetween(start: Instant, end: Instant): Long
+
+    @Query(
+        """
+        SELECT COUNT(s) FROM Subscription s
+        WHERE s.createdAt <= :asOf
+          AND (s.status IN ('ACTIVE', 'CANCELLING') OR s.currentPeriodEnd >= :asOf)
+        """
+    )
+    fun countActiveAsOf(asOf: Instant): Long
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/SubscriptionService.kt
@@ -76,6 +76,30 @@ internal class SubscriptionService(
         )
     }
 
+    override fun countActiveSubscriptionsByPlanType(): Map<String, Long> {
+        return subscriptionRepository
+            .countByStatusInGroupByPlanType(listOf(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELLING))
+            .associate { (it[0] as PlanType).name to it[1] as Long }
+    }
+
+    override fun countSubscriptionsExpiredBetween(start: Instant, end: Instant): Long {
+        return subscriptionRepository.countExpiredBetween(start, end)
+    }
+
+    override fun countActiveSubscriptionsAsOf(asOf: Instant): Long {
+        return subscriptionRepository.countActiveAsOf(asOf)
+    }
+
+    override fun sumRevenueBetween(start: Instant, end: Instant): BigDecimal {
+        return paymentHistoryRepository.sumRevenueBetween(start, end)
+    }
+
+    override fun sumRevenueBetweenByPlanType(start: Instant, end: Instant): Map<String, BigDecimal> {
+        return paymentHistoryRepository
+            .sumRevenueBetweenGroupByPlanType(start, end)
+            .associate { (it[0] as PlanType).name to it[1] as BigDecimal }
+    }
+
     // --- User-facing methods ---
 
     fun getAvailablePlans(): List<SubscriptionPlanResponse> {

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsAggregationSchedulerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsAggregationSchedulerTest.kt
@@ -1,0 +1,150 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import com.nickdferrara.fitify.scheduling.ClassUtilizationSummary
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.subscription.SubscriptionApi
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+class MetricsAggregationSchedulerTest {
+
+    private val repository = mockk<MetricsSnapshotRepository>()
+    private val subscriptionApi = mockk<SubscriptionApi>()
+    private val schedulingApi = mockk<SchedulingApi>()
+    private val scheduler = MetricsAggregationScheduler(repository, subscriptionApi, schedulingApi)
+
+    private val locationId = UUID.randomUUID()
+
+    @Test
+    fun `aggregateActiveSubscriptions stores counts by plan type and total`() {
+        val date = LocalDate.of(2025, 6, 15)
+
+        every { subscriptionApi.countActiveSubscriptionsByPlanType() } returns mapOf(
+            "MONTHLY" to 80L,
+            "ANNUAL" to 20L,
+        )
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.ACTIVE_SUBSCRIPTIONS, date)
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        scheduler.aggregateActiveSubscriptions(date)
+
+        verify(exactly = 3) { repository.save(any()) }
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.ACTIVE_SUBSCRIPTIONS &&
+                    it.dimensions.isEmpty() &&
+                    it.value == BigDecimal(100)
+            })
+        }
+    }
+
+    @Test
+    fun `aggregateRevenue stores revenue by plan type and total`() {
+        val date = LocalDate.of(2025, 6, 15)
+
+        every { subscriptionApi.sumRevenueBetweenByPlanType(any(), any()) } returns mapOf(
+            "MONTHLY" to BigDecimal("499.00"),
+            "ANNUAL" to BigDecimal("1999.00"),
+        )
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.REVENUE, date)
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        scheduler.aggregateRevenue(date)
+
+        verify(exactly = 3) { repository.save(any()) }
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.REVENUE &&
+                    it.dimensions.isEmpty() &&
+                    it.value.compareTo(BigDecimal("2498.00")) == 0
+            })
+        }
+    }
+
+    @Test
+    fun `aggregateClassUtilization computes average utilization per location`() {
+        val date = LocalDate.of(2025, 6, 15)
+
+        every { schedulingApi.getClassUtilizationByDateRange(any(), any()) } returns listOf(
+            ClassUtilizationSummary(UUID.randomUUID(), locationId, "yoga", 20, 16),
+            ClassUtilizationSummary(UUID.randomUUID(), locationId, "hiit", 20, 20),
+        )
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationId(MetricType.CLASS_UTILIZATION, date, locationId)
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        scheduler.aggregateClassUtilization(date)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.CLASS_UTILIZATION &&
+                    it.locationId == locationId &&
+                    it.value.toDouble() > 85.0 // (80% + 100%) / 2 = 90%
+            })
+        }
+    }
+
+    @Test
+    fun `aggregateChurnRate only runs on first day of month`() {
+        val nonFirstDay = LocalDate.of(2025, 6, 15)
+
+        scheduler.aggregateChurnRate(nonFirstDay)
+
+        verify(exactly = 0) { subscriptionApi.countSubscriptionsExpiredBetween(any(), any()) }
+    }
+
+    @Test
+    fun `aggregateChurnRate computes rate on first day of month`() {
+        val firstOfMonth = LocalDate.of(2025, 7, 1)
+
+        every { subscriptionApi.countSubscriptionsExpiredBetween(any(), any()) } returns 5
+        every { subscriptionApi.countActiveSubscriptionsAsOf(any()) } returns 100
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.CHURN_RATE, any())
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        scheduler.aggregateChurnRate(firstOfMonth)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.CHURN_RATE &&
+                    it.value.toDouble() == 5.0 // 5/100 * 100 = 5.0%
+            })
+        }
+    }
+
+    @Test
+    fun `aggregateChurnRate returns zero when no active subscriptions`() {
+        val firstOfMonth = LocalDate.of(2025, 7, 1)
+
+        every { subscriptionApi.countSubscriptionsExpiredBetween(any(), any()) } returns 0
+        every { subscriptionApi.countActiveSubscriptionsAsOf(any()) } returns 0
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.CHURN_RATE, any())
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        scheduler.aggregateChurnRate(firstOfMonth)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.CHURN_RATE &&
+                    it.value.compareTo(BigDecimal.ZERO) == 0
+            })
+        }
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsEventListenerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsEventListenerTest.kt
@@ -1,0 +1,169 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import com.nickdferrara.fitify.identity.UserRegisteredEvent
+import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
+import com.nickdferrara.fitify.scheduling.ClassSummary
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import com.nickdferrara.fitify.subscription.SubscriptionCreatedEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class MetricsEventListenerTest {
+
+    private val repository = mockk<MetricsSnapshotRepository>()
+    private val schedulingApi = mockk<SchedulingApi>()
+    private val listener = MetricsEventListener(repository, schedulingApi)
+
+    private val classId = UUID.randomUUID()
+    private val locationId = UUID.randomUUID()
+
+    private fun buildClassSummary() = ClassSummary(
+        id = classId,
+        name = "Morning Yoga",
+        description = null,
+        classType = "yoga",
+        startTime = Instant.now(),
+        endTime = Instant.now().plusSeconds(3600),
+        locationId = locationId,
+        coachId = UUID.randomUUID(),
+    )
+
+    @Test
+    fun `onUserRegistered creates signup snapshot`() {
+        val event = UserRegisteredEvent(UUID.randomUUID(), "test@test.com", "John", "Doe")
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.SIGNUPS, any())
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onUserRegistered(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.SIGNUPS &&
+                    it.value == BigDecimal.ONE &&
+                    it.locationId == null
+            })
+        }
+    }
+
+    @Test
+    fun `onUserRegistered increments existing snapshot`() {
+        val event = UserRegisteredEvent(UUID.randomUUID(), "test@test.com", "John", "Doe")
+        val existingSnapshot = MetricsSnapshot(
+            id = UUID.randomUUID(),
+            metricType = MetricType.SIGNUPS,
+            value = BigDecimal(5),
+            snapshotDate = LocalDate.now(),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.SIGNUPS, any())
+        } returns listOf(existingSnapshot)
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onUserRegistered(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.value == BigDecimal(6)
+            })
+        }
+    }
+
+    @Test
+    fun `onBookingCancelled creates cancellation snapshot with location`() {
+        val event = BookingCancelledEvent(UUID.randomUUID(), classId, Instant.now())
+
+        every { schedulingApi.findClassById(classId) } returns Result.Success(buildClassSummary())
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationId(MetricType.CANCELLATIONS, any(), locationId)
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onBookingCancelled(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.CANCELLATIONS &&
+                    it.locationId == locationId &&
+                    it.dimensions == mapOf("class_type" to "yoga") &&
+                    it.value == BigDecimal.ONE
+            })
+        }
+    }
+
+    @Test
+    fun `onBookingCancelled falls back to global when class not found`() {
+        val event = BookingCancelledEvent(UUID.randomUUID(), classId, Instant.now())
+
+        every { schedulingApi.findClassById(classId) } returns Result.Failure(NotFoundError("not found"))
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.CANCELLATIONS, any())
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onBookingCancelled(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.CANCELLATIONS &&
+                    it.locationId == null
+            })
+        }
+    }
+
+    @Test
+    fun `onSubscriptionCreated creates revenue snapshot with plan type dimension`() {
+        val event = SubscriptionCreatedEvent(UUID.randomUUID(), UUID.randomUUID(), "MONTHLY", "sub_123")
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationIdIsNull(MetricType.REVENUE, any())
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onSubscriptionCreated(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.REVENUE &&
+                    it.dimensions == mapOf("plan_type" to "MONTHLY") &&
+                    it.value == BigDecimal.ONE
+            })
+        }
+    }
+
+    @Test
+    fun `onWaitlistPromoted creates waitlist conversion snapshot with location`() {
+        val event = WaitlistPromotedEvent(UUID.randomUUID(), classId, "Morning Yoga", Instant.now())
+
+        every { schedulingApi.findClassById(classId) } returns Result.Success(buildClassSummary())
+        every {
+            repository.findByMetricTypeAndSnapshotDateAndLocationId(MetricType.WAITLIST_CONVERSION, any(), locationId)
+        } returns emptyList()
+        every { repository.save(any()) } answers { firstArg() }
+
+        listener.onWaitlistPromoted(event)
+
+        verify {
+            repository.save(match<MetricsSnapshot> {
+                it.metricType == MetricType.WAITLIST_CONVERSION &&
+                    it.locationId == locationId &&
+                    it.dimensions == mapOf("class_type" to "yoga")
+            })
+        }
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceTest.kt
@@ -1,0 +1,236 @@
+package com.nickdferrara.fitify.admin.internal.service
+
+import com.nickdferrara.fitify.admin.internal.entities.Granularity
+import com.nickdferrara.fitify.admin.internal.entities.MetricType
+import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
+import com.nickdferrara.fitify.admin.internal.exceptions.InvalidMetricsQueryException
+import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+class MetricsServiceTest {
+
+    private val repository = mockk<MetricsSnapshotRepository>()
+    private val service = MetricsService(repository)
+
+    private fun buildSnapshot(
+        metricType: MetricType = MetricType.SIGNUPS,
+        date: LocalDate = LocalDate.of(2025, 6, 1),
+        value: BigDecimal = BigDecimal.ONE,
+        locationId: UUID? = null,
+        dimensions: Map<String, String> = emptyMap(),
+    ) = MetricsSnapshot(
+        id = UUID.randomUUID(),
+        metricType = metricType,
+        locationId = locationId,
+        dimensions = dimensions,
+        value = value,
+        snapshotDate = date,
+    )
+
+    @Test
+    fun `getSignups returns daily data points`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 3)
+        val snapshots = listOf(
+            buildSnapshot(date = from, value = BigDecimal(5)),
+            buildSnapshot(date = from.plusDays(1), value = BigDecimal(3)),
+            buildSnapshot(date = to, value = BigDecimal(7)),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, any(), any())
+        } returns snapshots
+
+        val result = service.getSignups(from, to, Granularity.DAILY, null)
+
+        assertEquals(3, result.dataPoints.size)
+        assertEquals(MetricType.SIGNUPS, result.metricType)
+        assertEquals(Granularity.DAILY, result.granularity)
+    }
+
+    @Test
+    fun `getSignups rolls up to weekly`() {
+        val from = LocalDate.of(2025, 6, 2) // Monday
+        val to = LocalDate.of(2025, 6, 15)  // Sunday of week 2
+        val snapshots = (0L..13L).map { offset ->
+            buildSnapshot(date = from.plusDays(offset), value = BigDecimal.ONE)
+        }
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, any(), any())
+        } returns snapshots
+
+        val result = service.getSignups(from, to, Granularity.WEEKLY, null)
+
+        assertEquals(2, result.dataPoints.size)
+        assertEquals(BigDecimal(7), result.dataPoints[0].value)
+        assertEquals(BigDecimal(7), result.dataPoints[1].value)
+    }
+
+    @Test
+    fun `getSignups rolls up to monthly`() {
+        val from = LocalDate.of(2025, 5, 1)
+        val to = LocalDate.of(2025, 6, 30)
+        val maySnapshots = (0L..30L).map { offset ->
+            buildSnapshot(date = from.plusDays(offset), value = BigDecimal.ONE)
+        }
+        val juneSnapshots = (0L..29L).map { offset ->
+            buildSnapshot(date = LocalDate.of(2025, 6, 1).plusDays(offset), value = BigDecimal(2))
+        }
+        val allSnapshots = maySnapshots + juneSnapshots
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, any(), any())
+        } returns allSnapshots
+
+        val result = service.getSignups(from, to, Granularity.MONTHLY, null)
+
+        assertEquals(2, result.dataPoints.size)
+    }
+
+    @Test
+    fun `getMetric uses latest value for point-in-time metrics`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 7)
+        val snapshots = listOf(
+            buildSnapshot(metricType = MetricType.ACTIVE_SUBSCRIPTIONS, date = from, value = BigDecimal(100)),
+            buildSnapshot(metricType = MetricType.ACTIVE_SUBSCRIPTIONS, date = from.plusDays(3), value = BigDecimal(105)),
+            buildSnapshot(metricType = MetricType.ACTIVE_SUBSCRIPTIONS, date = to, value = BigDecimal(110)),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.ACTIVE_SUBSCRIPTIONS, any(), any())
+        } returns snapshots
+        // Other metric types return empty for overview
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(neq(MetricType.ACTIVE_SUBSCRIPTIONS), any(), any())
+        } returns emptyList()
+
+        val result = service.getOverview(from, to, null)
+        val activeSubs = result.metrics.find { it.metricType == MetricType.ACTIVE_SUBSCRIPTIONS }
+
+        assertNotNull(activeSubs)
+        assertEquals(BigDecimal(110), activeSubs!!.currentValue)
+    }
+
+    @Test
+    fun `trend comparison calculates change correctly`() {
+        val from = LocalDate.of(2025, 6, 4)
+        val to = LocalDate.of(2025, 6, 6)
+        val currentSnapshots = listOf(
+            buildSnapshot(date = from, value = BigDecimal(10)),
+            buildSnapshot(date = from.plusDays(1), value = BigDecimal(15)),
+            buildSnapshot(date = to, value = BigDecimal(5)),
+        )
+        val previousSnapshots = listOf(
+            buildSnapshot(date = from.minusDays(3), value = BigDecimal(8)),
+            buildSnapshot(date = from.minusDays(2), value = BigDecimal(12)),
+            buildSnapshot(date = from.minusDays(1), value = BigDecimal(10)),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, from, to)
+        } returns currentSnapshots
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, from.minusDays(3), from.minusDays(1))
+        } returns previousSnapshots
+
+        val result = service.getSignups(from, to, Granularity.DAILY, null)
+
+        assertNotNull(result.trend)
+        assertEquals(BigDecimal(30), result.trend!!.currentPeriodTotal)
+        assertEquals(BigDecimal(30), result.trend!!.previousPeriodTotal)
+        assertEquals(0, result.trend!!.changeAbsolute.compareTo(BigDecimal.ZERO))
+    }
+
+    @Test
+    fun `getSignups returns empty data points when no snapshots exist`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 7)
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, any(), any())
+        } returns emptyList()
+
+        val result = service.getSignups(from, to, Granularity.DAILY, null)
+
+        assertTrue(result.dataPoints.isEmpty())
+    }
+
+    @Test
+    fun `getSignups uses location-specific queries when locationId provided`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 3)
+        val locationId = UUID.randomUUID()
+        val snapshots = listOf(
+            buildSnapshot(date = from, value = BigDecimal(2), locationId = locationId),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationId(MetricType.SIGNUPS, any(), any(), locationId)
+        } returns snapshots
+
+        val result = service.getSignups(from, to, Granularity.DAILY, locationId)
+
+        assertEquals(1, result.dataPoints.size)
+    }
+
+    @Test
+    fun `getSignups throws when from is after to`() {
+        assertThrows<InvalidMetricsQueryException> {
+            service.getSignups(LocalDate.of(2025, 6, 10), LocalDate.of(2025, 6, 1), Granularity.DAILY, null)
+        }
+    }
+
+    @Test
+    fun `trend changePercent is null when previous period total is zero`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 3)
+        val currentSnapshots = listOf(
+            buildSnapshot(date = from, value = BigDecimal(10)),
+        )
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(MetricType.SIGNUPS, from, to)
+        } returns currentSnapshots
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(
+                MetricType.SIGNUPS,
+                from.minusDays(3),
+                from.minusDays(1),
+            )
+        } returns emptyList()
+
+        val result = service.getSignups(from, to, Granularity.DAILY, null)
+
+        assertNotNull(result.trend)
+        assertNull(result.trend!!.changePercent)
+    }
+
+    @Test
+    fun `overview returns all metric types`() {
+        val from = LocalDate.of(2025, 6, 1)
+        val to = LocalDate.of(2025, 6, 7)
+
+        every {
+            repository.findByMetricTypeAndSnapshotDateBetweenAndLocationIdIsNull(any(), any(), any())
+        } returns emptyList()
+
+        val result = service.getOverview(from, to, null)
+
+        assertEquals(7, result.metrics.size)
+        assertEquals(from, result.from)
+        assertEquals(to, result.to)
+        assertNull(result.locationId)
+    }
+}


### PR DESCRIPTION
## Summary

- Add pre-aggregated metrics endpoints for business intelligence and operational monitoring within the admin module
- Implement dual ingestion strategy: event listeners for real-time increment metrics (signups, cancellations, revenue, waitlist promotions) and a scheduled daily aggregation job for point-in-time snapshots (active subscriptions, class utilization, churn rate)
- Extend `SubscriptionApi` and `SchedulingApi` with aggregate query methods to support the metrics pipeline

## New files (15)

| File | Purpose |
|------|---------|
| `MetricType.kt` | Enum: SIGNUPS, CANCELLATIONS, REVENUE, ACTIVE_SUBSCRIPTIONS, CLASS_UTILIZATION, WAITLIST_CONVERSION, CHURN_RATE |
| `Granularity.kt` | Enum: DAILY, WEEKLY, MONTHLY |
| `MetricsSnapshot.kt` | JPA entity mapping to `metrics_snapshots` table with JSONB dimensions |
| `MetricsSnapshotRepository.kt` | Derived queries for fetching snapshots by metric type, date range, and location |
| `MetricsResponse.kt` | Response DTOs: `MetricDataPoint`, `TrendComparison`, `MetricResponse`, `MetricSummary`, `OverviewResponse` |
| `MetricsEventListener.kt` | Listens to `UserRegisteredEvent`, `BookingCancelledEvent`, `SubscriptionCreatedEvent`, `WaitlistPromotedEvent` to increment daily counters |
| `MetricsAggregationScheduler.kt` | `@Scheduled` daily job aggregating active subscriptions, revenue reconciliation, class utilization, and churn rate |
| `MetricsService.kt` | Query layer with daily/weekly/monthly rollup and trend comparison (current vs previous period) |
| `MetricsSchedulingConfig.kt` | `@Configuration @EnableScheduling` |
| `AdminMetricsController.kt` | REST endpoints at `/api/v1/admin/metrics/*` and `/api/v1/admin/locations/{id}/metrics/*` with `@PreAuthorize("hasRole('ADMIN')")` |
| `MetricsExceptions.kt` | `InvalidMetricsQueryException` for bad date ranges |
| `MetricsExceptionHandler.kt` | `@RestControllerAdvice` mapping to 400 |
| `MetricsServiceTest.kt` | 8 tests: rollup granularities, trend calculation, empty datasets, location filtering, validation |
| `MetricsEventListenerTest.kt` | 6 tests: each event type, increment existing snapshot, fallback on class not found |
| `MetricsAggregationSchedulerTest.kt` | 6 tests: each aggregation method, churn edge cases |

## Modified files (8)

| File | Changes |
|------|---------|
| `SubscriptionApi.kt` | +5 aggregate query methods (count active by plan type, count expired, count active as of, sum revenue, sum revenue by plan type) |
| `SubscriptionRepository.kt` | +3 JPQL queries for subscription counts |
| `PaymentHistoryRepository.kt` | +2 JPQL queries for revenue summation |
| `SubscriptionService.kt` | Implement the 5 new `SubscriptionApi` methods |
| `SchedulingApi.kt` | +`ClassUtilizationSummary` data class, +2 methods (utilization by date range, cancellation count) |
| `FitnessClassRepository.kt` | +1 JPQL query (`findWithBookingsByDateRange` with LEFT JOIN FETCH) |
| `BookingRepository.kt` | +2 JPQL queries for cancellation counts (global and per-location) |
| `SchedulingService.kt` | Implement the 2 new `SchedulingApi` methods |

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/admin/metrics/signups?from=&to=&granularity=&locationId=` | Sign-up metrics |
| GET | `/api/v1/admin/metrics/cancellations?from=&to=&granularity=&locationId=` | Cancellation metrics |
| GET | `/api/v1/admin/metrics/revenue?from=&to=&granularity=&locationId=` | Revenue metrics |
| GET | `/api/v1/admin/metrics/overview?from=&to=&locationId=` | All metrics summary (defaults to last 30 days) |
| GET | `/api/v1/admin/locations/{locationId}/metrics/overview?from=&to=` | Location-scoped overview |

## Test plan

- [x] `./gradlew build` passes with no errors
- [x] All 20 new unit tests pass (MetricsServiceTest, MetricsEventListenerTest, MetricsAggregationSchedulerTest)
- [x] All existing tests continue to pass (including ModulithStructureTest)
- [x] Verify endpoints manually with admin JWT against running instance