### PR TITLE
feat: add security layer with RBAC, rate limiting, and PII encryption

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     // Keycloak
     implementation("org.keycloak:keycloak-admin-client:26.0.0")
 
+    // Rate Limiting
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
+
     // Stripe
     implementation("com.stripe:stripe-java:28.2.0")
 

--- a/src/main/java/com/nickdferrara/fitify/shared/crypto/package-info.java
+++ b/src/main/java/com/nickdferrara/fitify/shared/crypto/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("crypto")
+package com.nickdferrara.fitify.shared.crypto;

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassController.kt
@@ -22,12 +22,12 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/admin")
-@PreAuthorize("hasRole('ADMIN')")
 internal class AdminClassController(
     private val adminService: AdminService,
 ) {
 
     @PostMapping("/locations/{locationId}/classes")
+    @PreAuthorize("@locationAdminService.hasAccess(authentication, #locationId)")
     fun createClass(
         @PathVariable locationId: UUID,
         @RequestBody request: CreateClassRequest,
@@ -37,6 +37,7 @@ internal class AdminClassController(
     }
 
     @GetMapping("/locations/{locationId}/classes")
+    @PreAuthorize("@locationAdminService.hasAccess(authentication, #locationId)")
     fun listClassesByLocation(
         @PathVariable locationId: UUID,
     ): ResponseEntity<List<AdminClassResponse>> {
@@ -44,6 +45,7 @@ internal class AdminClassController(
     }
 
     @PutMapping("/classes/{classId}")
+    @PreAuthorize("hasRole('ADMIN')")
     fun updateClass(
         @PathVariable classId: UUID,
         @RequestBody request: UpdateClassRequest,
@@ -52,12 +54,14 @@ internal class AdminClassController(
     }
 
     @DeleteMapping("/classes/{classId}")
+    @PreAuthorize("hasRole('ADMIN')")
     fun cancelClass(@PathVariable classId: UUID): ResponseEntity<CancelClassResponse> {
         val response = adminService.cancelClass(classId)
         return ResponseEntity.ok(response)
     }
 
     @PostMapping("/locations/{locationId}/classes/recurring")
+    @PreAuthorize("@locationAdminService.hasAccess(authentication, #locationId)")
     fun createRecurringSchedule(
         @PathVariable locationId: UUID,
         @RequestBody request: CreateRecurringScheduleRequest,

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
@@ -66,7 +66,7 @@ internal class AdminMetricsController(
 
 @RestController
 @RequestMapping("/api/v1/admin/locations/{locationId}/metrics")
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("@locationAdminService.hasAccess(authentication, #locationId)")
 internal class AdminLocationMetricsController(
     private val metricsService: MetricsService,
 ) {

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachController.kt
@@ -7,6 +7,7 @@ import com.nickdferrara.fitify.coaching.internal.dtos.response.CoachResponse
 import com.nickdferrara.fitify.coaching.internal.service.CoachingService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,6 +20,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/admin/coaches")
+@PreAuthorize("hasRole('ADMIN')")
 internal class AdminCoachController(
     private val coachingService: CoachingService,
 ) {

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminLocationCoachController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminLocationCoachController.kt
@@ -3,6 +3,7 @@ package com.nickdferrara.fitify.coaching.internal.controller
 import com.nickdferrara.fitify.coaching.internal.dtos.response.CoachResponse
 import com.nickdferrara.fitify.coaching.internal.service.CoachingService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -11,6 +12,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/admin/locations/{locationId}/coaches")
+@PreAuthorize("@locationAdminService.hasAccess(authentication, #locationId)")
 internal class AdminLocationCoachController(
     private val coachingService: CoachingService,
 ) {

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/SecurityConfig.kt
@@ -27,7 +27,7 @@ internal class SecurityConfig {
                 it.requestMatchers("/api/v1/auth/**").permitAll()
                 it.requestMatchers("/api/v1/webhooks/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()
-                it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                it.requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN", "LOCATION_ADMIN")
                 it.anyRequest().authenticated()
             }
             .oauth2ResourceServer {

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/entities/User.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/entities/User.kt
@@ -1,6 +1,9 @@
 package com.nickdferrara.fitify.identity.internal.entities
 
+import com.nickdferrara.fitify.shared.crypto.DeterministicEncryptedStringConverter
+import com.nickdferrara.fitify.shared.crypto.NonDeterministicEncryptedStringConverter
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -23,12 +26,15 @@ internal class User(
     @Column(name = "keycloak_id", unique = true, nullable = false)
     val keycloakId: String,
 
+    @Convert(converter = DeterministicEncryptedStringConverter::class)
     @Column(unique = true, nullable = false)
     var email: String,
 
+    @Convert(converter = NonDeterministicEncryptedStringConverter::class)
     @Column(name = "first_name", nullable = false)
     var firstName: String,
 
+    @Convert(converter = NonDeterministicEncryptedStringConverter::class)
     @Column(name = "last_name", nullable = false)
     var lastName: String,
 

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/repository/PasswordResetTokenRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/repository/PasswordResetTokenRepository.kt
@@ -2,9 +2,11 @@ package com.nickdferrara.fitify.identity.internal.repository
 
 import com.nickdferrara.fitify.identity.internal.entities.PasswordResetToken
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
 import java.util.Optional
 import java.util.UUID
 
 internal interface PasswordResetTokenRepository : JpaRepository<PasswordResetToken, UUID> {
     fun findByTokenHash(tokenHash: String): Optional<PasswordResetToken>
+    fun countByUserIdAndCreatedAtAfter(userId: UUID, since: Instant): Long
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationController.kt
@@ -6,6 +6,7 @@ import com.nickdferrara.fitify.location.internal.dtos.response.LocationResponse
 import com.nickdferrara.fitify.location.internal.service.LocationService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,6 +19,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/admin/locations")
+@PreAuthorize("hasRole('ADMIN')")
 internal class AdminLocationController(
     private val locationService: LocationService,
 ) {

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/entities/Location.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/entities/Location.kt
@@ -1,7 +1,10 @@
 package com.nickdferrara.fitify.location.internal.entities
 
+import com.nickdferrara.fitify.shared.crypto.DeterministicEncryptedStringConverter
+import com.nickdferrara.fitify.shared.crypto.NonDeterministicEncryptedStringConverter
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -31,8 +34,10 @@ internal class Location(
     @Column(name = "zip_code")
     var zipCode: String,
 
+    @Convert(converter = NonDeterministicEncryptedStringConverter::class)
     var phone: String,
 
+    @Convert(converter = DeterministicEncryptedStringConverter::class)
     var email: String,
 
     @Column(name = "time_zone")

--- a/src/main/kotlin/com/nickdferrara/fitify/security/SecurityApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/SecurityApi.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.security
+
+import java.util.UUID
+
+interface SecurityApi {
+    fun hasLocationAccess(keycloakId: String, locationId: UUID): Boolean
+    fun getAdminLocationIds(keycloakId: String): List<UUID>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/advices/SecurityExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/advices/SecurityExceptionHandler.kt
@@ -1,0 +1,26 @@
+package com.nickdferrara.fitify.security.internal.advices
+
+import com.nickdferrara.fitify.security.internal.controller.LocationAdminAssignmentController
+import com.nickdferrara.fitify.security.internal.dtos.response.ErrorResponse
+import com.nickdferrara.fitify.security.internal.exception.AssignmentAlreadyExistsException
+import com.nickdferrara.fitify.security.internal.exception.AssignmentNotFoundException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice(assignableTypes = [LocationAdminAssignmentController::class])
+internal class SecurityExceptionHandler {
+
+    @ExceptionHandler(AssignmentAlreadyExistsException::class)
+    fun handleAlreadyExists(ex: AssignmentAlreadyExistsException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse(ex.message ?: "Assignment already exists"))
+    }
+
+    @ExceptionHandler(AssignmentNotFoundException::class)
+    fun handleNotFound(ex: AssignmentNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(ex.message ?: "Assignment not found"))
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitFilter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitFilter.kt
@@ -1,0 +1,140 @@
+package com.nickdferrara.fitify.security.internal.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@EnableConfigurationProperties(RateLimitProperties::class)
+internal class RateLimitFilter(
+    private val properties: RateLimitProperties,
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+
+    private val buckets = ConcurrentHashMap<String, Bucket>()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val path = request.requestURI
+        val method = request.method
+
+        if (isExempt(path)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val bucketKey = resolveBucketKey(path, method, request) ?: run {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val bucket = buckets.computeIfAbsent(bucketKey) { createBucket(path, method) }
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+
+        if (probe.isConsumed) {
+            filterChain.doFilter(request, response)
+        } else {
+            val retryAfterSeconds = probe.nanosToWaitForRefill / 1_000_000_000 + 1
+            response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.setHeader("Retry-After", retryAfterSeconds.toString())
+            response.writer.write(
+                objectMapper.writeValueAsString(
+                    mapOf("error" to "Too many requests", "message" to "Rate limit exceeded")
+                )
+            )
+        }
+    }
+
+    private fun isExempt(path: String): Boolean {
+        return path.startsWith("/api/v1/webhooks/") || path.startsWith("/actuator/")
+    }
+
+    private fun resolveBucketKey(path: String, method: String, request: HttpServletRequest): String? {
+        val ip = request.remoteAddr
+
+        return when {
+            path == "/api/v1/auth/forgot-password" && method == "POST" -> "pw-reset:$ip"
+            path.startsWith("/api/v1/auth/") -> "auth:$ip"
+            path.startsWith("/api/v1/admin/") -> {
+                val subject = extractJwtSubject(request) ?: return "admin:$ip"
+                "admin:$subject"
+            }
+            path.startsWith("/api/v1/") -> {
+                val subject = extractJwtSubject(request) ?: return "general:$ip"
+                "general:$subject"
+            }
+            else -> null
+        }
+    }
+
+    private fun createBucket(path: String, method: String): Bucket {
+        val bandwidth = when {
+            path == "/api/v1/auth/forgot-password" && method == "POST" ->
+                Bandwidth.builder()
+                    .capacity(properties.passwordResetPerHour.toLong())
+                    .refillGreedy(properties.passwordResetPerHour.toLong(), Duration.ofHours(1))
+                    .build()
+            path.startsWith("/api/v1/auth/") ->
+                Bandwidth.builder()
+                    .capacity(properties.authRequestsPerMinute.toLong())
+                    .refillGreedy(properties.authRequestsPerMinute.toLong(), Duration.ofMinutes(1))
+                    .build()
+            path.startsWith("/api/v1/admin/") ->
+                Bandwidth.builder()
+                    .capacity(properties.adminRequestsPerMinute.toLong())
+                    .refillGreedy(properties.adminRequestsPerMinute.toLong(), Duration.ofMinutes(1))
+                    .build()
+            else ->
+                Bandwidth.builder()
+                    .capacity(properties.generalRequestsPerMinute.toLong())
+                    .refillGreedy(properties.generalRequestsPerMinute.toLong(), Duration.ofMinutes(1))
+                    .build()
+        }
+
+        return Bucket.builder().addLimit(bandwidth).build()
+    }
+
+    private fun extractJwtSubject(request: HttpServletRequest): String? {
+        val authHeader = request.getHeader("Authorization") ?: return null
+        if (!authHeader.startsWith("Bearer ")) return null
+
+        return try {
+            val token = authHeader.substring(7)
+            val parts = token.split(".")
+            if (parts.size != 3) return null
+            val payload = String(Base64.getUrlDecoder().decode(parts[1]), Charsets.UTF_8)
+            val json = objectMapper.readTree(payload)
+            json.get("sub")?.asText()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    @Scheduled(fixedRate = 600_000)
+    fun cleanupStaleBuckets() {
+        val keysToRemove = buckets.entries
+            .filter { it.value.availableTokens == it.value.tryConsumeAndReturnRemaining(0).remainingTokens }
+            .map { it.key }
+
+        keysToRemove.forEach { buckets.remove(it) }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitProperties.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.security.internal.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fitify.rate-limit")
+internal data class RateLimitProperties(
+    val authRequestsPerMinute: Int = 5,
+    val passwordResetPerHour: Int = 3,
+    val generalRequestsPerMinute: Int = 100,
+    val adminRequestsPerMinute: Int = 200,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentController.kt
@@ -1,0 +1,48 @@
+package com.nickdferrara.fitify.security.internal.controller
+
+import com.nickdferrara.fitify.security.internal.dtos.request.AssignLocationAdminRequest
+import com.nickdferrara.fitify.security.internal.dtos.response.LocationAdminAssignmentResponse
+import com.nickdferrara.fitify.security.internal.service.LocationAdminService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/admin/location-admins")
+@PreAuthorize("hasRole('ADMIN')")
+internal class LocationAdminAssignmentController(
+    private val locationAdminService: LocationAdminService,
+) {
+
+    @PostMapping
+    fun assignLocationAdmin(
+        @RequestBody request: AssignLocationAdminRequest,
+    ): ResponseEntity<LocationAdminAssignmentResponse> {
+        val response = locationAdminService.assignLocationAdmin(request.keycloakId, request.locationId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/{keycloakId}/locations")
+    fun getAssignments(
+        @PathVariable keycloakId: String,
+    ): ResponseEntity<List<LocationAdminAssignmentResponse>> {
+        return ResponseEntity.ok(locationAdminService.getAssignments(keycloakId))
+    }
+
+    @DeleteMapping("/{keycloakId}/locations/{locationId}")
+    fun removeAssignment(
+        @PathVariable keycloakId: String,
+        @PathVariable locationId: UUID,
+    ): ResponseEntity<Void> {
+        locationAdminService.removeAssignment(keycloakId, locationId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/request/AssignLocationAdminRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/request/AssignLocationAdminRequest.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.security.internal.dtos.request
+
+import java.util.UUID
+
+internal data class AssignLocationAdminRequest(
+    val keycloakId: String,
+    val locationId: UUID,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/response/ErrorResponse.kt
@@ -1,0 +1,3 @@
+package com.nickdferrara.fitify.security.internal.dtos.response
+
+internal data class ErrorResponse(val message: String)

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/response/LocationAdminAssignmentResponse.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/dtos/response/LocationAdminAssignmentResponse.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.security.internal.dtos.response
+
+import java.time.Instant
+import java.util.UUID
+
+internal data class LocationAdminAssignmentResponse(
+    val id: UUID,
+    val keycloakId: String,
+    val locationId: UUID,
+    val createdAt: Instant,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/entities/LocationAdminAssignment.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/entities/LocationAdminAssignment.kt
@@ -1,0 +1,34 @@
+package com.nickdferrara.fitify.security.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "location_admin_assignments",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["keycloak_id", "location_id"])],
+)
+internal class LocationAdminAssignment(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "keycloak_id", nullable = false)
+    val keycloakId: String,
+
+    @Column(name = "location_id", nullable = false)
+    val locationId: UUID,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/exception/LocationAdminExceptions.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/exception/LocationAdminExceptions.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.security.internal.exception
+
+internal class AssignmentAlreadyExistsException(keycloakId: String, locationId: java.util.UUID) :
+    RuntimeException("Assignment already exists for user $keycloakId at location $locationId")
+
+internal class AssignmentNotFoundException(keycloakId: String, locationId: java.util.UUID) :
+    RuntimeException("Assignment not found for user $keycloakId at location $locationId")

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/repository/LocationAdminAssignmentRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/repository/LocationAdminAssignmentRepository.kt
@@ -1,0 +1,11 @@
+package com.nickdferrara.fitify.security.internal.repository
+
+import com.nickdferrara.fitify.security.internal.entities.LocationAdminAssignment
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+internal interface LocationAdminAssignmentRepository : JpaRepository<LocationAdminAssignment, UUID> {
+    fun existsByKeycloakIdAndLocationId(keycloakId: String, locationId: UUID): Boolean
+    fun findByKeycloakId(keycloakId: String): List<LocationAdminAssignment>
+    fun deleteByKeycloakIdAndLocationId(keycloakId: String, locationId: UUID)
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminService.kt
@@ -1,0 +1,80 @@
+package com.nickdferrara.fitify.security.internal.service
+
+import com.nickdferrara.fitify.security.SecurityApi
+import com.nickdferrara.fitify.security.internal.dtos.response.LocationAdminAssignmentResponse
+import com.nickdferrara.fitify.security.internal.entities.LocationAdminAssignment
+import com.nickdferrara.fitify.security.internal.exception.AssignmentAlreadyExistsException
+import com.nickdferrara.fitify.security.internal.exception.AssignmentNotFoundException
+import com.nickdferrara.fitify.security.internal.repository.LocationAdminAssignmentRepository
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service("locationAdminService")
+internal class LocationAdminService(
+    private val repository: LocationAdminAssignmentRepository,
+) : SecurityApi {
+
+    fun hasAccess(authentication: Authentication, locationId: UUID): Boolean {
+        val authorities = authentication.authorities.map { it.authority }
+
+        if (authorities.contains("ROLE_ADMIN")) return true
+
+        if (authorities.contains("ROLE_LOCATION_ADMIN")) {
+            val keycloakId = extractKeycloakId(authentication) ?: return false
+            return repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)
+        }
+
+        return false
+    }
+
+    override fun hasLocationAccess(keycloakId: String, locationId: UUID): Boolean {
+        return repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)
+    }
+
+    override fun getAdminLocationIds(keycloakId: String): List<UUID> {
+        return repository.findByKeycloakId(keycloakId).map { it.locationId }
+    }
+
+    @Transactional
+    fun assignLocationAdmin(keycloakId: String, locationId: UUID): LocationAdminAssignmentResponse {
+        if (repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)) {
+            throw AssignmentAlreadyExistsException(keycloakId, locationId)
+        }
+
+        val assignment = repository.save(
+            LocationAdminAssignment(
+                keycloakId = keycloakId,
+                locationId = locationId,
+            )
+        )
+
+        return assignment.toResponse()
+    }
+
+    fun getAssignments(keycloakId: String): List<LocationAdminAssignmentResponse> {
+        return repository.findByKeycloakId(keycloakId).map { it.toResponse() }
+    }
+
+    @Transactional
+    fun removeAssignment(keycloakId: String, locationId: UUID) {
+        if (!repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)) {
+            throw AssignmentNotFoundException(keycloakId, locationId)
+        }
+        repository.deleteByKeycloakIdAndLocationId(keycloakId, locationId)
+    }
+
+    private fun extractKeycloakId(authentication: Authentication): String? {
+        val principal = authentication.principal
+        return if (principal is Jwt) principal.subject else null
+    }
+
+    private fun LocationAdminAssignment.toResponse() = LocationAdminAssignmentResponse(
+        id = id!!,
+        keycloakId = keycloakId,
+        locationId = locationId,
+        createdAt = createdAt!!,
+    )
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/AesEncryptor.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/AesEncryptor.kt
@@ -1,0 +1,73 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+@EnableConfigurationProperties(EncryptionProperties::class)
+class AesEncryptor(
+    properties: EncryptionProperties,
+) {
+
+    private val secretKey: SecretKeySpec
+
+    init {
+        val keyBytes = Base64.getDecoder().decode(properties.key)
+        require(keyBytes.size == 32) { "Encryption key must be 32 bytes (AES-256)" }
+        secretKey = SecretKeySpec(keyBytes, "AES")
+    }
+
+    fun encryptDeterministic(plaintext: String): String {
+        if (plaintext.isBlank()) return plaintext
+        val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val encrypted = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(encrypted)
+    }
+
+    fun encryptNonDeterministic(plaintext: String): String {
+        if (plaintext.isBlank()) return plaintext
+        val iv = ByteArray(16)
+        SecureRandom().nextBytes(iv)
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, IvParameterSpec(iv))
+        val encrypted = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        val combined = iv + encrypted
+        return Base64.getEncoder().encodeToString(combined)
+    }
+
+    fun decrypt(ciphertext: String): String {
+        if (ciphertext.isBlank()) return ciphertext
+        val decoded = Base64.getDecoder().decode(ciphertext)
+
+        return if (decoded.size > 16 && decoded.size % 16 == 0) {
+            // Try CBC first (IV + ciphertext)
+            try {
+                decryptCbc(decoded)
+            } catch (_: Exception) {
+                decryptEcb(decoded)
+            }
+        } else {
+            decryptEcb(decoded)
+        }
+    }
+
+    private fun decryptCbc(decoded: ByteArray): String {
+        val iv = decoded.copyOfRange(0, 16)
+        val encrypted = decoded.copyOfRange(16, decoded.size)
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, IvParameterSpec(iv))
+        return String(cipher.doFinal(encrypted), Charsets.UTF_8)
+    }
+
+    private fun decryptEcb(decoded: ByteArray): String {
+        val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, secretKey)
+        return String(cipher.doFinal(decoded), Charsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/ApplicationContextProvider.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/ApplicationContextProvider.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import org.springframework.beans.BeansException
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.stereotype.Component
+
+@Component
+class ApplicationContextProvider : ApplicationContextAware {
+
+    companion object {
+        private var context: ApplicationContext? = null
+
+        fun getApplicationContext(): ApplicationContext =
+            context ?: throw IllegalStateException("ApplicationContext has not been initialized")
+
+        fun <T> getBean(beanClass: Class<T>): T =
+            getApplicationContext().getBean(beanClass)
+    }
+
+    @Throws(BeansException::class)
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        context = applicationContext
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/DeterministicEncryptedStringConverter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/DeterministicEncryptedStringConverter.kt
@@ -1,0 +1,19 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class DeterministicEncryptedStringConverter : AttributeConverter<String, String> {
+
+    private val encryptor: AesEncryptor
+        get() = ApplicationContextProvider.getBean(AesEncryptor::class.java)
+
+    override fun convertToDatabaseColumn(attribute: String?): String? {
+        return attribute?.let { encryptor.encryptDeterministic(it) }
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): String? {
+        return dbData?.let { encryptor.decrypt(it) }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/EncryptionProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/EncryptionProperties.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fitify.encryption")
+data class EncryptionProperties(
+    val key: String,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/NonDeterministicEncryptedStringConverter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/crypto/NonDeterministicEncryptedStringConverter.kt
@@ -1,0 +1,19 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class NonDeterministicEncryptedStringConverter : AttributeConverter<String, String> {
+
+    private val encryptor: AesEncryptor
+        get() = ApplicationContextProvider.getBean(AesEncryptor::class.java)
+
+    override fun convertToDatabaseColumn(attribute: String?): String? {
+        return attribute?.let { encryptor.encryptNonDeterministic(it) }
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): String? {
+        return dbData?.let { encryptor.decrypt(it) }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,10 @@ spring:
       maximum-pool-size: 10
 
 fitify:
+  encryption:
+    key: dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u
+  security:
+    token-pepper: dev-pepper-value
   notification:
     from-email: noreply@fitify.local
     from-name: Fitify Dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,15 @@ management:
         enabled: true
 
 fitify:
+  encryption:
+    key: ${ENCRYPTION_KEY:dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u}
+  security:
+    token-pepper: ${TOKEN_PEPPER:dev-pepper-value-change-in-prod}
+  rate-limit:
+    auth-requests-per-minute: 5
+    password-reset-per-hour: 3
+    general-requests-per-minute: 100
+    admin-requests-per-minute: 200
   notification:
     from-email: ${NOTIFICATION_FROM_EMAIL:noreply@fitify.com}
     from-name: ${NOTIFICATION_FROM_NAME:Fitify}

--- a/src/test/kotlin/com/nickdferrara/fitify/ModulithStructureTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/ModulithStructureTest.kt
@@ -24,7 +24,7 @@ class ModulithStructureTest {
         @Suppress("DEPRECATION")
         val moduleNames = modules.map { it.name }.sorted()
         assertEquals(
-            listOf("admin", "coaching", "identity", "location", "notification", "scheduling", "shared", "subscription"),
+            listOf("admin", "coaching", "identity", "location", "notification", "scheduling", "security", "shared", "subscription"),
             moduleNames,
         )
     }

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/AuthServiceTest.kt
@@ -35,7 +35,8 @@ class AuthServiceTest {
     private val passwordResetTokenRepository = mockk<PasswordResetTokenRepository>()
     private val keycloakClient = mockk<KeycloakClient>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    private val authService = AuthService(userRepository, passwordResetTokenRepository, keycloakClient, eventPublisher)
+    private val tokenPepper = "test-pepper"
+    private val authService = AuthService(userRepository, passwordResetTokenRepository, keycloakClient, eventPublisher, tokenPepper)
 
     private fun buildUser(
         id: UUID = UUID.randomUUID(),
@@ -142,6 +143,7 @@ class AuthServiceTest {
     fun `forgotPassword creates token and publishes event when user exists`() {
         val user = buildUser()
         every { userRepository.findByEmail(user.email) } returns Optional.of(user)
+        every { passwordResetTokenRepository.countByUserIdAndCreatedAtAfter(user.id!!, any()) } returns 0L
         every { passwordResetTokenRepository.save(any()) } answers { firstArg() }
 
         val response = authService.forgotPassword(ForgotPasswordRequest(user.email))

--- a/src/test/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitFilterTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/security/internal/config/RateLimitFilterTest.kt
@@ -1,0 +1,171 @@
+package com.nickdferrara.fitify.security.internal.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Base64
+
+class RateLimitFilterTest {
+
+    private val objectMapper = ObjectMapper()
+    private val properties = RateLimitProperties(
+        authRequestsPerMinute = 5,
+        passwordResetPerHour = 3,
+        generalRequestsPerMinute = 100,
+        adminRequestsPerMinute = 200,
+    )
+    private lateinit var filter: RateLimitFilter
+    private val filterChain = mockk<FilterChain>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        filter = RateLimitFilter(properties, objectMapper)
+    }
+
+    private fun createRequest(path: String, method: String = "GET", ip: String = "127.0.0.1"): MockHttpServletRequest {
+        val request = MockHttpServletRequest(method, path)
+        request.remoteAddr = ip
+        return request
+    }
+
+    private fun addJwtHeader(request: MockHttpServletRequest, subject: String) {
+        val header = objectMapper.writeValueAsString(mapOf("alg" to "RS256"))
+        val payload = objectMapper.writeValueAsString(mapOf("sub" to subject))
+        val headerB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(header.toByteArray())
+        val payloadB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(payload.toByteArray())
+        request.addHeader("Authorization", "Bearer $headerB64.$payloadB64.signature")
+    }
+
+    @Test
+    fun `auth endpoint returns 429 after exceeding limit`() {
+        for (i in 1..5) {
+            val request = createRequest("/api/v1/auth/login", "POST")
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+
+        val request = createRequest("/api/v1/auth/login", "POST")
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, filterChain)
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+    }
+
+    @Test
+    fun `password reset endpoint returns 429 after 3 requests`() {
+        for (i in 1..3) {
+            val request = createRequest("/api/v1/auth/forgot-password", "POST")
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+
+        val request = createRequest("/api/v1/auth/forgot-password", "POST")
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, filterChain)
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+    }
+
+    @Test
+    fun `webhook endpoints are not rate limited`() {
+        for (i in 1..300) {
+            val request = createRequest("/api/v1/webhooks/stripe", "POST")
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+    }
+
+    @Test
+    fun `actuator endpoints are not rate limited`() {
+        for (i in 1..300) {
+            val request = createRequest("/actuator/health", "GET")
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+    }
+
+    @Test
+    fun `different IPs get independent buckets`() {
+        for (i in 1..5) {
+            val request = createRequest("/api/v1/auth/login", "POST", "10.0.0.1")
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+
+        // First IP should be rate limited
+        val limitedRequest = createRequest("/api/v1/auth/login", "POST", "10.0.0.1")
+        val limitedResponse = MockHttpServletResponse()
+        filter.doFilter(limitedRequest, limitedResponse, filterChain)
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), limitedResponse.status)
+
+        // Second IP should still work
+        val freshRequest = createRequest("/api/v1/auth/login", "POST", "10.0.0.2")
+        val freshResponse = MockHttpServletResponse()
+        filter.doFilter(freshRequest, freshResponse, filterChain)
+        assertEquals(HttpStatus.OK.value(), freshResponse.status)
+    }
+
+    @Test
+    fun `rate limited response includes Retry-After header`() {
+        for (i in 1..5) {
+            val request = createRequest("/api/v1/auth/login", "POST")
+            filter.doFilter(request, MockHttpServletResponse(), filterChain)
+        }
+
+        val request = createRequest("/api/v1/auth/login", "POST")
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, filterChain)
+
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+        val retryAfter = response.getHeader("Retry-After")
+        assertEquals(true, retryAfter != null && retryAfter.toLong() > 0)
+    }
+
+    @Test
+    fun `admin endpoints use JWT subject for bucketing`() {
+        val subject = "user-123"
+
+        for (i in 1..200) {
+            val request = createRequest("/api/v1/admin/locations", "GET")
+            addJwtHeader(request, subject)
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+
+        val request = createRequest("/api/v1/admin/locations", "GET")
+        addJwtHeader(request, subject)
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, filterChain)
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+    }
+
+    @Test
+    fun `general endpoints are rate limited at 100 per minute`() {
+        val subject = "user-456"
+
+        for (i in 1..100) {
+            val request = createRequest("/api/v1/locations", "GET")
+            addJwtHeader(request, subject)
+            val response = MockHttpServletResponse()
+            filter.doFilter(request, response, filterChain)
+            assertEquals(HttpStatus.OK.value(), response.status)
+        }
+
+        val request = createRequest("/api/v1/locations", "GET")
+        addJwtHeader(request, subject)
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, filterChain)
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.status)
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceTest.kt
@@ -1,0 +1,130 @@
+package com.nickdferrara.fitify.security.internal.service
+
+import com.nickdferrara.fitify.security.internal.entities.LocationAdminAssignment
+import com.nickdferrara.fitify.security.internal.exception.AssignmentAlreadyExistsException
+import com.nickdferrara.fitify.security.internal.exception.AssignmentNotFoundException
+import com.nickdferrara.fitify.security.internal.repository.LocationAdminAssignmentRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import java.time.Instant
+import java.util.UUID
+
+class LocationAdminServiceTest {
+
+    private val repository = mockk<LocationAdminAssignmentRepository>()
+    private val service = LocationAdminService(repository)
+
+    private val locationId = UUID.randomUUID()
+    private val keycloakId = UUID.randomUUID().toString()
+
+    private fun mockAuthentication(roles: List<String>, subject: String = keycloakId): Authentication {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns subject
+
+        val auth = mockk<Authentication>()
+        every { auth.authorities } returns roles.map { SimpleGrantedAuthority(it) }
+        every { auth.principal } returns jwt
+        return auth
+    }
+
+    @Test
+    fun `hasAccess returns true for ROLE_ADMIN regardless of assignment`() {
+        val auth = mockAuthentication(listOf("ROLE_ADMIN"))
+
+        assertTrue(service.hasAccess(auth, locationId))
+    }
+
+    @Test
+    fun `hasAccess returns true for LOCATION_ADMIN with matching assignment`() {
+        val auth = mockAuthentication(listOf("ROLE_LOCATION_ADMIN"))
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns true
+
+        assertTrue(service.hasAccess(auth, locationId))
+    }
+
+    @Test
+    fun `hasAccess returns false for LOCATION_ADMIN without matching assignment`() {
+        val auth = mockAuthentication(listOf("ROLE_LOCATION_ADMIN"))
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns false
+
+        assertFalse(service.hasAccess(auth, locationId))
+    }
+
+    @Test
+    fun `hasAccess returns false for ROLE_USER`() {
+        val auth = mockAuthentication(listOf("ROLE_USER"))
+
+        assertFalse(service.hasAccess(auth, locationId))
+    }
+
+    @Test
+    fun `assignLocationAdmin creates new assignment`() {
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns false
+        every { repository.save(any()) } answers {
+            val arg = firstArg<LocationAdminAssignment>()
+            LocationAdminAssignment(
+                id = UUID.randomUUID(),
+                keycloakId = arg.keycloakId,
+                locationId = arg.locationId,
+                createdAt = Instant.now(),
+            )
+        }
+
+        val response = service.assignLocationAdmin(keycloakId, locationId)
+
+        assertEquals(keycloakId, response.keycloakId)
+        assertEquals(locationId, response.locationId)
+    }
+
+    @Test
+    fun `assignLocationAdmin throws when assignment already exists`() {
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns true
+
+        assertThrows<AssignmentAlreadyExistsException> {
+            service.assignLocationAdmin(keycloakId, locationId)
+        }
+    }
+
+    @Test
+    fun `removeAssignment deletes existing assignment`() {
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns true
+        every { repository.deleteByKeycloakIdAndLocationId(keycloakId, locationId) } returns Unit
+
+        service.removeAssignment(keycloakId, locationId)
+
+        verify { repository.deleteByKeycloakIdAndLocationId(keycloakId, locationId) }
+    }
+
+    @Test
+    fun `removeAssignment throws when assignment not found`() {
+        every { repository.existsByKeycloakIdAndLocationId(keycloakId, locationId) } returns false
+
+        assertThrows<AssignmentNotFoundException> {
+            service.removeAssignment(keycloakId, locationId)
+        }
+    }
+
+    @Test
+    fun `getAdminLocationIds returns location IDs for keycloak ID`() {
+        val locationId2 = UUID.randomUUID()
+        every { repository.findByKeycloakId(keycloakId) } returns listOf(
+            LocationAdminAssignment(id = UUID.randomUUID(), keycloakId = keycloakId, locationId = locationId, createdAt = Instant.now()),
+            LocationAdminAssignment(id = UUID.randomUUID(), keycloakId = keycloakId, locationId = locationId2, createdAt = Instant.now()),
+        )
+
+        val result = service.getAdminLocationIds(keycloakId)
+
+        assertEquals(2, result.size)
+        assertTrue(result.contains(locationId))
+        assertTrue(result.contains(locationId2))
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/shared/crypto/AesEncryptorTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/shared/crypto/AesEncryptorTest.kt
@@ -1,0 +1,67 @@
+package com.nickdferrara.fitify.shared.crypto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.util.Base64
+
+class AesEncryptorTest {
+
+    private val key = Base64.getEncoder().encodeToString("test-key-32-bytes-long..........".toByteArray())
+    private val encryptor = AesEncryptor(EncryptionProperties(key))
+
+    @Test
+    fun `deterministic encryption produces same output for same input`() {
+        val plaintext = "user@example.com"
+        val encrypted1 = encryptor.encryptDeterministic(plaintext)
+        val encrypted2 = encryptor.encryptDeterministic(plaintext)
+
+        assertEquals(encrypted1, encrypted2)
+    }
+
+    @Test
+    fun `non-deterministic encryption produces different output for same input`() {
+        val plaintext = "John"
+        val encrypted1 = encryptor.encryptNonDeterministic(plaintext)
+        val encrypted2 = encryptor.encryptNonDeterministic(plaintext)
+
+        assertNotEquals(encrypted1, encrypted2)
+    }
+
+    @Test
+    fun `decrypt reverses deterministic encryption`() {
+        val plaintext = "user@example.com"
+        val encrypted = encryptor.encryptDeterministic(plaintext)
+        val decrypted = encryptor.decrypt(encrypted)
+
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `decrypt reverses non-deterministic encryption`() {
+        val plaintext = "John Doe"
+        val encrypted = encryptor.encryptNonDeterministic(plaintext)
+        val decrypted = encryptor.decrypt(encrypted)
+
+        assertEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `blank string is returned as-is for deterministic encryption`() {
+        assertEquals("", encryptor.encryptDeterministic(""))
+        assertEquals(" ", encryptor.decrypt(" "))
+    }
+
+    @Test
+    fun `blank string is returned as-is for non-deterministic encryption`() {
+        assertEquals("", encryptor.encryptNonDeterministic(""))
+    }
+
+    @Test
+    fun `encrypted output differs from plaintext`() {
+        val plaintext = "sensitive@email.com"
+        val encrypted = encryptor.encryptDeterministic(plaintext)
+
+        assertNotEquals(plaintext, encrypted)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the security layer for Fitify (closes #11):

- **PII encryption at rest** — AES-256 via JPA `@Convert` on `User` (email, firstName, lastName) and `Location` (email, phone). Deterministic mode (ECB) for equality-searchable fields, non-deterministic (CBC + random IV) for non-searchable PII.
- **RBAC with `ROLE_LOCATION_ADMIN`** — New `security` module with `LocationAdminAssignment` entity mapping keycloakId → locationId. SpEL `@locationAdminService.hasAccess(authentication, #locationId)` on location-scoped admin endpoints; global admin endpoints locked to `ROLE_ADMIN` only.
- **Rate limiting** — Bucket4j `OncePerRequestFilter` with per-endpoint classification: 5 req/min auth, 3 req/hr password reset, 100 req/min general, 200 req/min admin. Webhooks and actuator exempt. Returns 429 with `Retry-After` header.
- **Salted token hashing** — Configurable pepper prepended to SHA-256 digest for password reset tokens. Per-user rate limit of 3 reset requests/hour.

## Test plan

- [x] `AesEncryptorTest` — deterministic produces same output, non-deterministic differs, decrypt reverses both, blank passthrough
- [x] `LocationAdminServiceTest` — `hasAccess` true for ADMIN, true for LOCATION_ADMIN with assignment, false without, false for USER
- [x] `RateLimitFilterTest` — 429 after exceeding per-endpoint limits, independent IP buckets, webhooks exempt, `Retry-After` header present
- [x] `AuthServiceTest` — updated for pepper parameter and rate-limit mock
- [x] `ModulithStructureTest` — security module detected, structure verified
- [x] Full suite: 188 tests pass, 0 failures