### PR TITLE
Decouple identity module from Keycloak SDK via gateway pattern

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/advices/IdentityExceptionHandler.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/advices/IdentityExceptionHandler.kt
@@ -6,8 +6,8 @@ import com.nickdferrara.fitify.identity.internal.dtos.response.ErrorResponse
 import com.nickdferrara.fitify.identity.internal.exception.EmailAlreadyExistsException
 import com.nickdferrara.fitify.identity.internal.exception.InvalidTokenException
 import com.nickdferrara.fitify.identity.internal.exception.UserNotFoundException
+import com.nickdferrara.fitify.identity.internal.exception.IdentityProviderException
 import com.nickdferrara.fitify.identity.internal.exception.WeakPasswordException
-import com.nickdferrara.fitify.identity.internal.service.KeycloakException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -46,8 +46,8 @@ internal class IdentityExceptionHandler {
             .body(ErrorResponse(ex.message ?: "Invalid argument"))
     }
 
-    @ExceptionHandler(KeycloakException::class)
-    fun handleKeycloak(ex: KeycloakException): ResponseEntity<ErrorResponse> {
+    @ExceptionHandler(IdentityProviderException::class)
+    fun handleIdentityProvider(ex: IdentityProviderException): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
             .body(ErrorResponse(ex.message ?: "Identity provider unavailable"))
     }

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/exception/IdentityProviderConflictException.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/exception/IdentityProviderConflictException.kt
@@ -1,0 +1,3 @@
+package com.nickdferrara.fitify.identity.internal.exception
+
+internal class IdentityProviderConflictException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/exception/IdentityProviderException.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/exception/IdentityProviderException.kt
@@ -1,0 +1,3 @@
+package com.nickdferrara.fitify.identity.internal.exception
+
+internal class IdentityProviderException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/gateway/IdentityProviderGateway.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/gateway/IdentityProviderGateway.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.identity.internal.gateway
+
+internal interface IdentityProviderGateway {
+    fun createUser(email: String, password: String, firstName: String, lastName: String): String
+    fun updatePassword(keycloakId: String, newPassword: String)
+    fun invalidateSessions(keycloakId: String)
+}


### PR DESCRIPTION
## Summary
- Introduce `IdentityProviderGateway` interface as an anti-corruption layer so `AuthService` depends on a port instead of the concrete `KeycloakClient`
- Encapsulate all Keycloak SDK types in `KeycloakIdentityProviderGateway` adapter
- Replace Keycloak-specific exceptions with domain exceptions (`IdentityProviderException`, `IdentityProviderConflictException`)
- Delete `KeycloakClient.kt` and move integration test to `KeycloakIdentityProviderGatewayIntegrationTest`

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` passes
- [x] `./gradlew test --tests "com.nickdferrara.fitify.identity.*"` passes (unit tests)
- [x] `./gradlew test` full suite passes
- [x] Integration test (`KeycloakIdentityProviderGatewayIntegrationTest`) requires Docker

Closes #19