### PR TITLE
feat: add centralized logging and observability module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,12 @@ dependencies {
     // Stripe
     implementation("com.stripe:stripe-java:28.2.0")
 
+    // AOP
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
+    // Logging
+    implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+
     // Notification
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("com.google.firebase:firebase-admin:9.4.3")
@@ -114,6 +120,7 @@ val modulePackages = mapOf(
     "security" to "com/nickdferrara/fitify/security/**",
     "shared" to "com/nickdferrara/fitify/shared/**",
     "subscription" to "com/nickdferrara/fitify/subscription/**",
+    "logging" to "com/nickdferrara/fitify/logging/**",
 )
 
 val commonExcludes = listOf(
@@ -125,6 +132,8 @@ val commonExcludes = listOf(
     "**/*Advice*",
     "**/entities/**",
     "**/dtos/**",
+    "**/*Aspect*",
+    "**/*Filter*",
 )
 
 tasks.jacocoTestCoverageVerification {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,55 @@ services:
     networks:
       - fitify-network
 
+  loki:
+    image: grafana/loki:3.3.2
+    container_name: fitify-loki
+    profiles: [observability]
+    command: -config.file=/etc/loki/loki-config.yml
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./infra/loki/loki-config.yml:/etc/loki/loki-config.yml
+      - loki-data:/loki
+    networks:
+      - fitify-network
+
+  promtail:
+    image: grafana/promtail:3.3.2
+    container_name: fitify-promtail
+    profiles: [observability]
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./infra/promtail/promtail-config.yml:/etc/promtail/promtail-config.yml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - loki
+    networks:
+      - fitify-network
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: fitify-grafana
+    profiles: [observability]
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning
+    depends_on:
+      - loki
+    networks:
+      - fitify-network
+
 volumes:
   fitify-pgdata:
+  loki-data:
+  grafana-data:
 
 networks:
   fitify-network:

--- a/infra/grafana/provisioning/dashboards/auth-security.json
+++ b/infra/grafana/provisioning/dashboards/auth-security.json
@@ -1,0 +1,155 @@
+{
+  "uid": "fitify-auth-security",
+  "title": "Auth & Security",
+  "tags": ["fitify", "security", "auth"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Authentication Errors Over Time",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "color": {"fixedColor": "red", "mode": "fixed"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=~\"security|identity\"} |~ \"(?i)(auth|login|token|jwt|unauthorized|forbidden|401|403)\" | level =~ \"ERROR|WARN\" [$__interval]))",
+          "legendFormat": "Auth Errors"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Login Failure Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "lineWidth": 1
+          },
+          "color": {"fixedColor": "orange", "mode": "fixed"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=~\"security|identity\"} |~ \"(?i)(login.*fail|authentication.*fail|invalid.*credentials|bad.*credentials|access.*denied)\" [$__interval]))",
+          "legendFormat": "Login Failures"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=~\"security|identity\"} |~ \"(?i)(login.*success|authenticated|token.*issued)\" [$__interval]))",
+          "legendFormat": "Login Successes"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Top IPs with Failed Auth",
+      "type": "table",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{"displayName": "Value", "desc": true}]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "topk(10, sum by (userId) (count_over_time({module=~\"security|identity\", level=~\"ERROR|WARN\"} |~ \"(?i)(auth|login|unauthorized|forbidden|denied)\" | userId != \"\" [$__range])))",
+          "legendFormat": "{{userId}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Security Event Logs",
+      "type": "logs",
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "{module=~\"security|identity\", level=~\"ERROR|WARN\"} |~ \"(?i)(auth|login|token|jwt|unauthorized|forbidden|denied)\" | json",
+          "maxLines": 200
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/dashboard.yml
+++ b/infra/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Fitify Dashboards'
+    orgId: 1
+    folder: 'Fitify'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning/dashboards/notifications.json
+++ b/infra/grafana/provisioning/dashboards/notifications.json
@@ -1,0 +1,140 @@
+{
+  "uid": "fitify-notifications",
+  "title": "Notifications",
+  "tags": ["fitify", "notifications"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Notification Delivery Logs",
+      "type": "logs",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "{module=\"notification\"} |~ \"(?i)(deliver|send|sent|email|sms|push|dispatch)\" | json",
+          "maxLines": 200
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Notification Errors",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "color": {"fixedColor": "red", "mode": "fixed"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"notification\", level=\"ERROR\"} [$__interval]))",
+          "legendFormat": "Errors"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"notification\", level=\"WARN\"} [$__interval]))",
+          "legendFormat": "Warnings"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Delivery Success / Failure Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "stacking": {"mode": "normal"}
+          },
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Delivered"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Failed"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"notification\"} |~ \"(?i)(delivered|sent|success)\" [$__interval]))",
+          "legendFormat": "Delivered"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"notification\"} |~ \"(?i)(fail|error|bounce|reject)\" [$__interval]))",
+          "legendFormat": "Failed"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/operations-overview.json
+++ b/infra/grafana/provisioning/dashboards/operations-overview.json
@@ -1,0 +1,173 @@
+{
+  "uid": "fitify-operations-overview",
+  "title": "Operations Overview",
+  "tags": ["fitify", "operations"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": {"type": "loki", "uid": "${datasource}"},
+        "query": {"type": 1, "label": "service"},
+        "current": {},
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume Over Time (by Level)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "stacking": {"mode": "normal"}
+          },
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "ERROR"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "WARN"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "INFO"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "DEBUG"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (level) (count_over_time({service=~\"$service\"} [$__interval]))",
+          "legendFormat": "{{level}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Error Rate by Module",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "lineWidth": 2
+          },
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (module) (count_over_time({service=~\"$service\", level=\"ERROR\"} | module != \"\" [$__interval]))",
+          "legendFormat": "{{module}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Top 10 Error Messages",
+      "type": "table",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{"displayName": "Value", "desc": true}]
+      },
+      "transformations": [
+        {"id": "sortBy", "options": {"sort": [{"field": "Value", "desc": true}]}},
+        {"id": "limit", "options": {"limitField": 10}}
+      ],
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "topk(10, sum by (message) (count_over_time({service=~\"$service\", level=\"ERROR\"} | json | __error__=\"\" [$__range])))",
+          "legendFormat": "{{message}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Log Volume by Module",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "stacking": {"mode": "normal"}
+          },
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (module) (count_over_time({service=~\"$service\"} | module != \"\" [$__interval]))",
+          "legendFormat": "{{module}}"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/payments.json
+++ b/infra/grafana/provisioning/dashboards/payments.json
@@ -1,0 +1,166 @@
+{
+  "uid": "fitify-payments",
+  "title": "Payments",
+  "tags": ["fitify", "payments", "subscription"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Payment & Subscription Errors",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "color": {"fixedColor": "red", "mode": "fixed"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"subscription\", level=\"ERROR\"} |~ \"(?i)(payment|stripe|charge|invoice|billing)\" [$__interval]))",
+          "legendFormat": "Payment Errors"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"subscription\", level=\"WARN\"} |~ \"(?i)(payment|stripe|charge|invoice|billing)\" [$__interval]))",
+          "legendFormat": "Payment Warnings"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Stripe Webhook Events",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "stacking": {"mode": "normal"}
+          },
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (level) (count_over_time({module=\"subscription\"} |~ \"(?i)(webhook|stripe.*event)\" [$__interval]))",
+          "legendFormat": "{{level}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Payment Failure Rate",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "color": {"mode": "palette-classic"},
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Failure Rate"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"subscription\", level=\"ERROR\"} |~ \"(?i)(payment|charge|invoice)\" [$__interval])) / (sum (count_over_time({module=\"subscription\"} |~ \"(?i)(payment|charge|invoice)\" [$__interval])) > 0)",
+          "legendFormat": "Failure Rate"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Payment Event Logs",
+      "type": "logs",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "{module=\"subscription\"} |~ \"(?i)(payment|stripe|charge|invoice|webhook|billing)\" | json",
+          "maxLines": 200
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/request-tracing.json
+++ b/infra/grafana/provisioning/dashboards/request-tracing.json
@@ -1,0 +1,132 @@
+{
+  "uid": "fitify-request-tracing",
+  "title": "Request Tracing",
+  "tags": ["fitify", "tracing"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
+        "name": "correlationId",
+        "type": "textbox",
+        "label": "Correlation ID",
+        "current": {"text": "", "value": ""},
+        "hide": 0,
+        "options": [],
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "All Logs for Correlation ID",
+      "description": "Shows every log line matching the specified correlationId. Enter a correlation ID in the variable above.",
+      "type": "logs",
+      "gridPos": {"h": 14, "w": 24, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Ascending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "{correlationId=\"$correlationId\"} | json",
+          "maxLines": 500
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Request Timeline",
+      "description": "Log entries over time for the specified correlationId, grouped by level.",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 16, "x": 0, "y": 14},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "points",
+            "pointSize": 8,
+            "lineWidth": 0
+          },
+          "color": {"mode": "palette-classic"}
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "ERROR"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "WARN"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "INFO"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (level) (count_over_time({correlationId=\"$correlationId\"} [$__interval]))",
+          "legendFormat": "{{level}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Modules Touched by Request",
+      "description": "Which modules were involved in processing this request.",
+      "type": "table",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 14},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum by (module, level) (count_over_time({correlationId=\"$correlationId\"} | module != \"\" [$__range]))",
+          "legendFormat": "{{module}} - {{level}}",
+          "instant": true
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/dashboards/scheduling.json
+++ b/infra/grafana/provisioning/dashboards/scheduling.json
@@ -1,0 +1,140 @@
+{
+  "uid": "fitify-scheduling",
+  "title": "Scheduling",
+  "tags": ["fitify", "scheduling"],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Booking Activity Logs",
+      "type": "logs",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 0},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "{module=\"scheduling\"} |~ \"(?i)(book|cancel|reschedule|appointment|session|class|slot)\" | json",
+          "maxLines": 200
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Scheduling Errors",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "color": {"fixedColor": "red", "mode": "fixed"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"scheduling\", level=\"ERROR\"} [$__interval]))",
+          "legendFormat": "Errors"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"scheduling\", level=\"WARN\"} [$__interval]))",
+          "legendFormat": "Warnings"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Class Booking Volume",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "datasource": {"type": "loki", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "stacking": {"mode": "normal"}
+          },
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Bookings"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Cancellations"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]}
+        ]
+      },
+      "options": {
+        "tooltip": {"mode": "multi"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"scheduling\"} |~ \"(?i)(booked|created|confirmed|scheduled)\" [$__interval]))",
+          "legendFormat": "Bookings"
+        },
+        {
+          "refId": "B",
+          "datasource": {"type": "loki", "uid": "${datasource}"},
+          "expr": "sum (count_over_time({module=\"scheduling\"} |~ \"(?i)(cancel|cancelled|canceled)\" [$__interval]))",
+          "legendFormat": "Cancellations"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/datasources/loki.yml
+++ b/infra/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/infra/loki/loki-config.yml
+++ b/infra/loki/loki-config.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 90d
+  max_query_length: 721h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/infra/promtail/promtail-config.yml
+++ b/infra/promtail/promtail-config.yml
@@ -1,0 +1,45 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: label
+            values: ["com.docker.compose.project=server-springboot-fitify"]
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'service'
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            correlationId: correlationId
+            userId: userId
+            module: module
+            message: message
+            timestamp: "@timestamp"
+      - labels:
+          level:
+          logger:
+          correlationId:
+          userId:
+          module:
+      - timestamp:
+          source: timestamp
+          format: "2006-01-02T15:04:05.000Z07:00"
+          fallback_formats:
+            - "2006-01-02T15:04:05.000Z"

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/Audit.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/Audit.kt
@@ -1,0 +1,9 @@
+package com.nickdferrara.fitify.logging
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Audit(
+    val action: String,
+    val resourceType: String,
+    val includeResult: Boolean = false,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/LogExecution.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/LogExecution.kt
@@ -1,0 +1,14 @@
+package com.nickdferrara.fitify.logging
+
+enum class LogLevel {
+    TRACE, DEBUG, INFO, WARN, ERROR
+}
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LogExecution(
+    val level: LogLevel = LogLevel.INFO,
+    val includeArgs: Boolean = true,
+    val includeResult: Boolean = false,
+    val timed: Boolean = true,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/LoggingApi.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/LoggingApi.kt
@@ -1,0 +1,26 @@
+package com.nickdferrara.fitify.logging
+
+import java.time.Instant
+import java.util.UUID
+
+data class AuditLogResponse(
+    val id: UUID,
+    val timestamp: Instant,
+    val userId: String,
+    val action: String,
+    val module: String,
+    val resourceType: String,
+    val resourceId: String?,
+    val details: String?,
+    val ipAddress: String?,
+)
+
+interface LoggingApi {
+    fun queryAuditLogs(
+        userId: String? = null,
+        action: String? = null,
+        module: String? = null,
+        from: Instant? = null,
+        to: Instant? = null,
+    ): List<AuditLogResponse>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/Sensitive.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/Sensitive.kt
@@ -1,0 +1,5 @@
+package com.nickdferrara.fitify.logging
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Sensitive

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/AuditAspect.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/AuditAspect.kt
@@ -1,0 +1,71 @@
+package com.nickdferrara.fitify.logging.internal.aspect
+
+import com.nickdferrara.fitify.logging.Audit
+import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
+import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.MDC
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.util.UUID
+
+@Aspect
+internal class AuditAspect(
+    private val auditLogService: AuditLogService,
+    private val properties: LoggingProperties,
+) {
+
+    @Around("@annotation(audit)")
+    fun auditMethod(joinPoint: ProceedingJoinPoint, audit: Audit): Any? {
+        if (!properties.audit.enabled) return joinPoint.proceed()
+
+        val result = joinPoint.proceed()
+
+        val userId = MDC.get("userId") ?: "anonymous"
+        val module = MDC.get("module") ?: "unknown"
+        val resourceId = extractResourceId(joinPoint.args)
+        val ipAddress = extractIpAddress()
+
+        val details = if (audit.includeResult && result != null) {
+            result.toString()
+        } else {
+            null
+        }
+
+        auditLogService.save(
+            userId = userId,
+            action = audit.action,
+            module = module,
+            resourceType = audit.resourceType,
+            resourceId = resourceId,
+            details = details,
+            ipAddress = ipAddress,
+        )
+
+        return result
+    }
+
+    private fun extractResourceId(args: Array<Any?>): String? {
+        return args.firstNotNullOfOrNull { arg ->
+            when (arg) {
+                is UUID -> arg.toString()
+                is Long -> arg.toString()
+                is String -> if (arg.length <= 64) arg else null
+                else -> null
+            }
+        }
+    }
+
+    private fun extractIpAddress(): String? {
+        return try {
+            val request = (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)
+                ?.request
+            request?.getHeader("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
+                ?: request?.remoteAddr
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/ExceptionLoggingAspect.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/ExceptionLoggingAspect.kt
@@ -1,0 +1,47 @@
+package com.nickdferrara.fitify.logging.internal.aspect
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterThrowing
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+
+@Aspect
+internal class ExceptionLoggingAspect {
+
+    @AfterThrowing(
+        pointcut = "within(@org.springframework.web.bind.annotation.RestController *) || within(@org.springframework.stereotype.Service *)",
+        throwing = "ex",
+    )
+    fun logException(joinPoint: JoinPoint, ex: Throwable) {
+        val logger = LoggerFactory.getLogger(joinPoint.target::class.java)
+        val methodName = joinPoint.signature.name
+        val className = joinPoint.target::class.simpleName
+        val correlationId = MDC.get("correlationId") ?: "unknown"
+        val userId = MDC.get("userId") ?: "anonymous"
+
+        if (isBusinessException(ex)) {
+            logger.warn(
+                "Business exception in {}.{} [correlationId={}, userId={}]: {}",
+                className, methodName, correlationId, userId, ex.message,
+            )
+        } else {
+            logger.error(
+                "Exception in {}.{} [correlationId={}, userId={}]: {}",
+                className, methodName, correlationId, userId, ex.message, ex,
+            )
+        }
+    }
+
+    private fun isBusinessException(ex: Throwable): Boolean {
+        val exceptionName = ex::class.simpleName ?: return false
+        return exceptionName.contains("NotFound") ||
+            exceptionName.contains("Validation") ||
+            exceptionName.contains("Conflict") ||
+            exceptionName.contains("Unauthorized") ||
+            exceptionName.contains("IllegalArgument") ||
+            ex is IllegalArgumentException ||
+            ex is IllegalStateException ||
+            ex is NoSuchElementException
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/LoggingAspect.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/LoggingAspect.kt
@@ -1,0 +1,116 @@
+package com.nickdferrara.fitify.logging.internal.aspect
+
+import com.nickdferrara.fitify.logging.LogExecution
+import com.nickdferrara.fitify.logging.LogLevel
+import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
+import com.nickdferrara.fitify.logging.internal.service.SensitiveDataMasker
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@Aspect
+internal class LoggingAspect(
+    private val properties: LoggingProperties,
+    private val sensitiveDataMasker: SensitiveDataMasker,
+) {
+
+    @Around("@annotation(logExecution)")
+    fun logAnnotatedMethod(joinPoint: ProceedingJoinPoint, logExecution: LogExecution): Any? {
+        val logger = LoggerFactory.getLogger(joinPoint.target::class.java)
+        return executeWithLogging(
+            joinPoint = joinPoint,
+            logger = logger,
+            level = logExecution.level,
+            includeArgs = logExecution.includeArgs,
+            includeResult = logExecution.includeResult,
+            timed = logExecution.timed,
+        )
+    }
+
+    @Around("within(@org.springframework.web.bind.annotation.RestController *) && execution(public * *(..))")
+    fun logControllerMethod(joinPoint: ProceedingJoinPoint): Any? {
+        if (!properties.aop.controllerLogging) return joinPoint.proceed()
+        if (hasLogExecutionAnnotation(joinPoint)) return joinPoint.proceed()
+
+        val logger = LoggerFactory.getLogger(joinPoint.target::class.java)
+        return executeWithLogging(
+            joinPoint = joinPoint,
+            logger = logger,
+            level = LogLevel.INFO,
+            includeArgs = true,
+            includeResult = false,
+            timed = true,
+        )
+    }
+
+    @Around("within(@org.springframework.stereotype.Service *) && execution(public * *(..))")
+    fun logServiceMethod(joinPoint: ProceedingJoinPoint): Any? {
+        if (!properties.aop.serviceLogging) return joinPoint.proceed()
+        if (hasLogExecutionAnnotation(joinPoint)) return joinPoint.proceed()
+
+        val logger = LoggerFactory.getLogger(joinPoint.target::class.java)
+        return executeWithLogging(
+            joinPoint = joinPoint,
+            logger = logger,
+            level = LogLevel.DEBUG,
+            includeArgs = true,
+            includeResult = false,
+            timed = true,
+        )
+    }
+
+    private fun executeWithLogging(
+        joinPoint: ProceedingJoinPoint,
+        logger: Logger,
+        level: LogLevel,
+        includeArgs: Boolean,
+        includeResult: Boolean,
+        timed: Boolean,
+    ): Any? {
+        val methodName = joinPoint.signature.name
+        val className = joinPoint.target::class.simpleName
+
+        val argsString = if (includeArgs && joinPoint.args.isNotEmpty()) {
+            if (properties.aop.maskSensitiveFields) {
+                sensitiveDataMasker.maskArgs(joinPoint.args)
+            } else {
+                joinPoint.args.map { it?.toString() ?: "null" }
+            }.joinToString(", ")
+        } else {
+            ""
+        }
+
+        log(logger, level, "{}.{} called{}", className, methodName,
+            if (argsString.isNotEmpty()) " with args: [$argsString]" else "")
+
+        val startTime = if (timed) System.currentTimeMillis() else 0L
+        val result = joinPoint.proceed()
+        val duration = if (timed) System.currentTimeMillis() - startTime else 0L
+
+        val resultString = if (includeResult && result != null) " returned: $result" else ""
+        val timeString = if (timed) " [${duration}ms]" else ""
+
+        log(logger, level, "{}.{} completed{}{}",
+            className, methodName, timeString, resultString)
+
+        return result
+    }
+
+    private fun log(logger: Logger, level: LogLevel, message: String, vararg args: Any?) {
+        when (level) {
+            LogLevel.TRACE -> logger.trace(message, *args)
+            LogLevel.DEBUG -> logger.debug(message, *args)
+            LogLevel.INFO -> logger.info(message, *args)
+            LogLevel.WARN -> logger.warn(message, *args)
+            LogLevel.ERROR -> logger.error(message, *args)
+        }
+    }
+
+    private fun hasLogExecutionAnnotation(joinPoint: ProceedingJoinPoint): Boolean {
+        val method = (joinPoint.signature as MethodSignature).method
+        return method.isAnnotationPresent(LogExecution::class.java)
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/CorrelationIdFilter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/CorrelationIdFilter.kt
@@ -1,0 +1,70 @@
+package com.nickdferrara.fitify.logging.internal.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.Base64
+import java.util.UUID
+
+internal class CorrelationIdFilter(
+    private val properties: LoggingProperties,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            val correlationId = request.getHeader(properties.correlationHeader)
+                ?: UUID.randomUUID().toString()
+            MDC.put("correlationId", correlationId)
+
+            val userId = extractUserIdFromJwt(request)
+            if (userId != null) {
+                MDC.put("userId", userId)
+            }
+
+            val module = extractModuleFromPath(request.requestURI)
+            if (module != null) {
+                MDC.put("module", module)
+            }
+
+            response.setHeader(properties.correlationHeader, correlationId)
+
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove("correlationId")
+            MDC.remove("userId")
+            MDC.remove("module")
+        }
+    }
+
+    private fun extractUserIdFromJwt(request: HttpServletRequest): String? {
+        val authHeader = request.getHeader("Authorization") ?: return null
+        if (!authHeader.startsWith("Bearer ")) return null
+
+        return try {
+            val token = authHeader.substringAfter("Bearer ")
+            val parts = token.split(".")
+            if (parts.size < 2) return null
+
+            val payload = String(Base64.getUrlDecoder().decode(parts[1]))
+            val subMatch = Regex(""""sub"\s*:\s*"([^"]+)"""").find(payload)
+            subMatch?.groupValues?.get(1)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun extractModuleFromPath(path: String): String? {
+        val segments = path.removePrefix("/api/v1/").split("/")
+        return when {
+            segments.isEmpty() -> null
+            segments[0] == "admin" && segments.size > 1 -> segments[1]
+            else -> segments[0]
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingConfig.kt
@@ -1,0 +1,63 @@
+package com.nickdferrara.fitify.logging.internal.config
+
+import com.nickdferrara.fitify.logging.internal.aspect.AuditAspect
+import com.nickdferrara.fitify.logging.internal.aspect.ExceptionLoggingAspect
+import com.nickdferrara.fitify.logging.internal.aspect.LoggingAspect
+import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.SensitiveDataMasker
+import org.slf4j.MDC
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.task.ThreadPoolTaskExecutorCustomizer
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.task.TaskDecorator
+
+@Configuration
+@EnableConfigurationProperties(LoggingProperties::class)
+internal class LoggingConfig {
+
+    @Bean
+    fun correlationIdFilter(properties: LoggingProperties): FilterRegistrationBean<CorrelationIdFilter> {
+        val registration = FilterRegistrationBean(CorrelationIdFilter(properties))
+        registration.order = Ordered.HIGHEST_PRECEDENCE
+        return registration
+    }
+
+    @Bean
+    fun mdcTaskExecutorCustomizer(): ThreadPoolTaskExecutorCustomizer {
+        return ThreadPoolTaskExecutorCustomizer { executor ->
+            executor.setTaskDecorator(MdcTaskDecorator())
+        }
+    }
+
+    @Bean
+    fun loggingAspect(properties: LoggingProperties, masker: SensitiveDataMasker): LoggingAspect {
+        return LoggingAspect(properties, masker)
+    }
+
+    @Bean
+    fun exceptionLoggingAspect(): ExceptionLoggingAspect {
+        return ExceptionLoggingAspect()
+    }
+
+    @Bean
+    fun auditAspect(auditLogService: AuditLogService, properties: LoggingProperties): AuditAspect {
+        return AuditAspect(auditLogService, properties)
+    }
+}
+
+internal class MdcTaskDecorator : TaskDecorator {
+    override fun decorate(runnable: Runnable): Runnable {
+        val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
+        return Runnable {
+            try {
+                MDC.setContextMap(contextMap)
+                runnable.run()
+            } finally {
+                MDC.clear()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingProperties.kt
@@ -1,0 +1,22 @@
+package com.nickdferrara.fitify.logging.internal.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("fitify.logging")
+internal data class LoggingProperties(
+    val correlationHeader: String = "X-Correlation-ID",
+    val aop: AopProperties = AopProperties(),
+    val audit: AuditProperties = AuditProperties(),
+) {
+    data class AopProperties(
+        val controllerLogging: Boolean = true,
+        val serviceLogging: Boolean = true,
+        val maskSensitiveFields: Boolean = true,
+    )
+
+    data class AuditProperties(
+        val enabled: Boolean = true,
+        val retentionDays: Int = 90,
+        val async: Boolean = true,
+    )
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/controller/AuditLogController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/controller/AuditLogController.kt
@@ -1,0 +1,32 @@
+package com.nickdferrara.fitify.logging.internal.controller
+
+import com.nickdferrara.fitify.logging.AuditLogResponse
+import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/api/v1/admin/audit-logs")
+@PreAuthorize("hasRole('ADMIN')")
+internal class AuditLogController(
+    private val auditLogService: AuditLogService,
+) {
+
+    @GetMapping
+    fun queryAuditLogs(
+        @RequestParam(required = false) userId: String?,
+        @RequestParam(required = false) action: String?,
+        @RequestParam(required = false) module: String?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+    ): ResponseEntity<List<AuditLogResponse>> {
+        val logs = auditLogService.queryAuditLogs(userId, action, module, from, to)
+        return ResponseEntity.ok(logs)
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/entities/AuditLogEntity.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/entities/AuditLogEntity.kt
@@ -1,0 +1,43 @@
+package com.nickdferrara.fitify.logging.internal.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "audit_logs")
+internal class AuditLogEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @CreationTimestamp
+    @Column(name = "timestamp", updatable = false)
+    val timestamp: Instant? = null,
+
+    @Column(name = "user_id")
+    val userId: String,
+
+    val action: String,
+
+    val module: String,
+
+    @Column(name = "resource_type")
+    val resourceType: String,
+
+    @Column(name = "resource_id")
+    val resourceId: String? = null,
+
+    @Column(columnDefinition = "text")
+    val details: String? = null,
+
+    @Column(name = "ip_address")
+    val ipAddress: String? = null,
+)

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/repository/AuditLogRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/repository/AuditLogRepository.kt
@@ -1,0 +1,32 @@
+package com.nickdferrara.fitify.logging.internal.repository
+
+import com.nickdferrara.fitify.logging.internal.entities.AuditLogEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
+import java.util.UUID
+
+internal interface AuditLogRepository : JpaRepository<AuditLogEntity, UUID> {
+
+    @Query(
+        """
+        SELECT a FROM AuditLogEntity a
+        WHERE (:userId IS NULL OR a.userId = :userId)
+        AND (:action IS NULL OR a.action = :action)
+        AND (:module IS NULL OR a.module = :module)
+        AND (:from IS NULL OR a.timestamp >= :from)
+        AND (:to IS NULL OR a.timestamp <= :to)
+        ORDER BY a.timestamp DESC
+        """,
+    )
+    fun findByFilters(
+        userId: String?,
+        action: String?,
+        module: String?,
+        from: Instant?,
+        to: Instant?,
+        pageable: Pageable,
+    ): Page<AuditLogEntity>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/AuditLogService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/AuditLogService.kt
@@ -1,0 +1,68 @@
+package com.nickdferrara.fitify.logging.internal.service
+
+import com.nickdferrara.fitify.logging.AuditLogResponse
+import com.nickdferrara.fitify.logging.LoggingApi
+import com.nickdferrara.fitify.logging.internal.entities.AuditLogEntity
+import com.nickdferrara.fitify.logging.internal.repository.AuditLogRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+internal class AuditLogService(
+    private val auditLogRepository: AuditLogRepository,
+) : LoggingApi {
+
+    @Transactional
+    fun save(
+        userId: String,
+        action: String,
+        module: String,
+        resourceType: String,
+        resourceId: String?,
+        details: String?,
+        ipAddress: String?,
+    ) {
+        auditLogRepository.save(
+            AuditLogEntity(
+                userId = userId,
+                action = action,
+                module = module,
+                resourceType = resourceType,
+                resourceId = resourceId,
+                details = details,
+                ipAddress = ipAddress,
+            ),
+        )
+    }
+
+    override fun queryAuditLogs(
+        userId: String?,
+        action: String?,
+        module: String?,
+        from: Instant?,
+        to: Instant?,
+    ): List<AuditLogResponse> {
+        return auditLogRepository.findByFilters(
+            userId = userId,
+            action = action,
+            module = module,
+            from = from,
+            to = to,
+            pageable = PageRequest.of(0, 100),
+        ).content.map { it.toResponse() }
+    }
+
+    private fun AuditLogEntity.toResponse() = AuditLogResponse(
+        id = id!!,
+        timestamp = timestamp!!,
+        userId = userId,
+        action = action,
+        module = module,
+        resourceType = resourceType,
+        resourceId = resourceId,
+        details = details,
+        ipAddress = ipAddress,
+    )
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/SensitiveDataMasker.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/SensitiveDataMasker.kt
@@ -1,0 +1,53 @@
+package com.nickdferrara.fitify.logging.internal.service
+
+import com.nickdferrara.fitify.logging.Sensitive
+import org.springframework.stereotype.Component
+
+@Component
+internal class SensitiveDataMasker {
+
+    companion object {
+        const val MASKED_VALUE = "***MASKED***"
+        private val SENSITIVE_FIELD_NAMES = setOf(
+            "password", "secret", "token", "apikey", "apiKey",
+            "creditcard", "creditCard", "creditCardNumber",
+            "ssn", "authorization",
+        )
+    }
+
+    fun maskArgs(args: Array<Any?>): List<String> {
+        return args.map { arg -> maskValue(arg) }
+    }
+
+    private fun maskValue(value: Any?): String {
+        if (value == null) return "null"
+
+        return try {
+            val clazz = value::class
+            val fields = clazz.java.declaredFields
+
+            val hasSensitiveFields = fields.any { field ->
+                isSensitiveFieldName(field.name) || field.isAnnotationPresent(Sensitive::class.java)
+            }
+
+            if (!hasSensitiveFields) return value.toString()
+
+            val masked = fields.map { field ->
+                field.isAccessible = true
+                val fieldValue = field.get(value)
+                if (isSensitiveFieldName(field.name) || field.isAnnotationPresent(Sensitive::class.java)) {
+                    "${field.name}=$MASKED_VALUE"
+                } else {
+                    "${field.name}=$fieldValue"
+                }
+            }
+            "${clazz.simpleName}(${masked.joinToString(", ")})"
+        } catch (_: Exception) {
+            value.toString()
+        }
+    }
+
+    private fun isSensitiveFieldName(name: String): Boolean {
+        return SENSITIVE_FIELD_NAMES.any { it.equals(name, ignoreCase = true) }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/package-info.java
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.nickdferrara.fitify.logging;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,16 @@ fitify:
     webhook-secret: ${STRIPE_WEBHOOK_SECRET:whsec_placeholder}
     success-url: ${STRIPE_SUCCESS_URL:http://localhost:3000/subscription/success}
     cancel-url: ${STRIPE_CANCEL_URL:http://localhost:3000/subscription/cancel}
+  logging:
+    correlation-header: X-Correlation-ID
+    aop:
+      controller-logging: true
+      service-logging: true
+      mask-sensitive-fields: true
+    audit:
+      enabled: true
+      retention-days: 90
+      async: true
 
 server:
   port: 8080

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <springProfile name="dev | default">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] [%X{correlationId:-}] [%X{userId:-}] [%X{module:-}] %cyan(%logger{36}) - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+
+        <logger name="com.nickdferrara.fitify" level="DEBUG" />
+    </springProfile>
+
+    <springProfile name="staging | prod">
+        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>correlationId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>module</includeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="JSON" />
+        </root>
+
+        <logger name="com.nickdferrara.fitify" level="INFO" />
+    </springProfile>
+
+</configuration>

--- a/src/test/kotlin/com/nickdferrara/fitify/ModulithStructureTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/ModulithStructureTest.kt
@@ -24,7 +24,7 @@ class ModulithStructureTest {
         @Suppress("DEPRECATION")
         val moduleNames = modules.map { it.name }.sorted()
         assertEquals(
-            listOf("admin", "coaching", "identity", "location", "notification", "scheduling", "security", "shared", "subscription"),
+            listOf("admin", "coaching", "identity", "location", "logging", "notification", "scheduling", "security", "shared", "subscription"),
             moduleNames,
         )
     }

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditAspectTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditAspectTest.kt
@@ -1,0 +1,156 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.Audit
+import com.nickdferrara.fitify.logging.internal.aspect.AuditAspect
+import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
+import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.aspectj.lang.ProceedingJoinPoint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import java.util.UUID
+
+class AuditAspectTest {
+
+    private val auditLogService = mockk<AuditLogService>(relaxed = true)
+    private val properties = LoggingProperties()
+    private lateinit var auditAspect: AuditAspect
+
+    @BeforeEach
+    fun setup() {
+        auditAspect = AuditAspect(auditLogService, properties)
+        MDC.clear()
+    }
+
+    private fun createJoinPoint(
+        args: Array<Any?> = emptyArray(),
+        result: Any? = "result",
+    ): ProceedingJoinPoint {
+        val joinPoint = mockk<ProceedingJoinPoint>()
+        every { joinPoint.args } returns args
+        every { joinPoint.proceed() } returns result
+        return joinPoint
+    }
+
+    @Test
+    fun `audit annotation triggers audit record creation`() {
+        MDC.put("userId", "user-123")
+        MDC.put("module", "coaching")
+
+        val resourceId = UUID.randomUUID()
+        val joinPoint = createJoinPoint(args = arrayOf(resourceId))
+        val audit = mockk<Audit>()
+        every { audit.action } returns "COACH_CREATED"
+        every { audit.resourceType } returns "Coach"
+        every { audit.includeResult } returns false
+
+        val result = auditAspect.auditMethod(joinPoint, audit)
+
+        assertEquals("result", result)
+        verify {
+            auditLogService.save(
+                userId = "user-123",
+                action = "COACH_CREATED",
+                module = "coaching",
+                resourceType = "Coach",
+                resourceId = resourceId.toString(),
+                details = null,
+                ipAddress = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `extracts resource ID from UUID argument`() {
+        MDC.put("userId", "user-1")
+        MDC.put("module", "scheduling")
+
+        val uuid = UUID.randomUUID()
+        val joinPoint = createJoinPoint(args = arrayOf(uuid))
+        val audit = mockk<Audit>()
+        every { audit.action } returns "CLASS_CANCELLED"
+        every { audit.resourceType } returns "FitnessClass"
+        every { audit.includeResult } returns false
+
+        auditAspect.auditMethod(joinPoint, audit)
+
+        verify {
+            auditLogService.save(
+                userId = any(),
+                action = any(),
+                module = any(),
+                resourceType = any(),
+                resourceId = uuid.toString(),
+                details = any(),
+                ipAddress = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `skips audit when disabled`() {
+        val disabledProperties = LoggingProperties(
+            audit = LoggingProperties.AuditProperties(enabled = false),
+        )
+        val aspect = AuditAspect(auditLogService, disabledProperties)
+        val joinPoint = createJoinPoint()
+        val audit = mockk<Audit>()
+
+        aspect.auditMethod(joinPoint, audit)
+
+        verify(exactly = 0) { auditLogService.save(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `includes result when includeResult is true`() {
+        MDC.put("userId", "user-1")
+        MDC.put("module", "test")
+
+        val joinPoint = createJoinPoint(result = "some-result-data")
+        val audit = mockk<Audit>()
+        every { audit.action } returns "ACTION"
+        every { audit.resourceType } returns "Resource"
+        every { audit.includeResult } returns true
+
+        auditAspect.auditMethod(joinPoint, audit)
+
+        verify {
+            auditLogService.save(
+                userId = any(),
+                action = any(),
+                module = any(),
+                resourceType = any(),
+                resourceId = any(),
+                details = "some-result-data",
+                ipAddress = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `uses anonymous when userId not in MDC`() {
+        val joinPoint = createJoinPoint()
+        val audit = mockk<Audit>()
+        every { audit.action } returns "ACTION"
+        every { audit.resourceType } returns "Resource"
+        every { audit.includeResult } returns false
+
+        auditAspect.auditMethod(joinPoint, audit)
+
+        verify {
+            auditLogService.save(
+                userId = "anonymous",
+                action = any(),
+                module = any(),
+                resourceType = any(),
+                resourceId = any(),
+                details = any(),
+                ipAddress = any(),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditLogServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditLogServiceTest.kt
@@ -1,0 +1,123 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.internal.entities.AuditLogEntity
+import com.nickdferrara.fitify.logging.internal.repository.AuditLogRepository
+import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import java.time.Instant
+import java.util.UUID
+
+class AuditLogServiceTest {
+
+    private val auditLogRepository = mockk<AuditLogRepository>(relaxed = true)
+    private val auditLogService = AuditLogService(auditLogRepository)
+
+    @Test
+    fun `save persists audit log entity`() {
+        val entitySlot = slot<AuditLogEntity>()
+        every { auditLogRepository.save(capture(entitySlot)) } answers { firstArg() }
+
+        auditLogService.save(
+            userId = "user-123",
+            action = "COACH_CREATED",
+            module = "coaching",
+            resourceType = "Coach",
+            resourceId = "abc-123",
+            details = """{"name":"John"}""",
+            ipAddress = "192.168.1.1",
+        )
+
+        verify { auditLogRepository.save(any()) }
+        assertEquals("user-123", entitySlot.captured.userId)
+        assertEquals("COACH_CREATED", entitySlot.captured.action)
+        assertEquals("coaching", entitySlot.captured.module)
+        assertEquals("Coach", entitySlot.captured.resourceType)
+        assertEquals("abc-123", entitySlot.captured.resourceId)
+        assertEquals("""{"name":"John"}""", entitySlot.captured.details)
+        assertEquals("192.168.1.1", entitySlot.captured.ipAddress)
+    }
+
+    @Test
+    fun `queryAuditLogs returns mapped responses`() {
+        val id = UUID.randomUUID()
+        val now = Instant.now()
+        val entity = AuditLogEntity(
+            id = id,
+            timestamp = now,
+            userId = "user-1",
+            action = "LOGIN",
+            module = "identity",
+            resourceType = "User",
+            resourceId = "user-1",
+            details = null,
+            ipAddress = "10.0.0.1",
+        )
+
+        every {
+            auditLogRepository.findByFilters(
+                userId = "user-1",
+                action = null,
+                module = null,
+                from = null,
+                to = null,
+                pageable = any(),
+            )
+        } returns PageImpl(listOf(entity))
+
+        val results = auditLogService.queryAuditLogs(userId = "user-1")
+
+        assertEquals(1, results.size)
+        assertEquals(id, results[0].id)
+        assertEquals("user-1", results[0].userId)
+        assertEquals("LOGIN", results[0].action)
+        assertEquals("identity", results[0].module)
+    }
+
+    @Test
+    fun `queryAuditLogs with all filters`() {
+        val from = Instant.parse("2025-01-01T00:00:00Z")
+        val to = Instant.parse("2025-12-31T23:59:59Z")
+
+        every {
+            auditLogRepository.findByFilters(
+                userId = "user-1",
+                action = "COACH_CREATED",
+                module = "coaching",
+                from = from,
+                to = to,
+                pageable = any(),
+            )
+        } returns PageImpl(emptyList())
+
+        val results = auditLogService.queryAuditLogs(
+            userId = "user-1",
+            action = "COACH_CREATED",
+            module = "coaching",
+            from = from,
+            to = to,
+        )
+
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun `queryAuditLogs with no filters returns all`() {
+        every {
+            auditLogRepository.findByFilters(null, null, null, null, null, any())
+        } returns PageImpl(emptyList())
+
+        val results = auditLogService.queryAuditLogs()
+
+        assertEquals(0, results.size)
+        verify {
+            auditLogRepository.findByFilters(null, null, null, null, null, any<Pageable>())
+        }
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/CorrelationIdFilterTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/CorrelationIdFilterTest.kt
@@ -1,0 +1,146 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.internal.config.CorrelationIdFilter
+import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.util.Base64
+
+class CorrelationIdFilterTest {
+
+    private val properties = LoggingProperties()
+    private lateinit var filter: CorrelationIdFilter
+    private val filterChain = mockk<FilterChain>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        filter = CorrelationIdFilter(properties)
+        MDC.clear()
+    }
+
+    @Test
+    fun `generates new correlation ID when header is missing`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        val response = MockHttpServletResponse()
+
+        var capturedCorrelationId: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedCorrelationId = MDC.get("correlationId")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertNotNull(capturedCorrelationId)
+        assertNotNull(response.getHeader("X-Correlation-ID"))
+        assertEquals(capturedCorrelationId, response.getHeader("X-Correlation-ID"))
+    }
+
+    @Test
+    fun `preserves existing correlation ID from header`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        request.addHeader("X-Correlation-ID", "existing-correlation-id")
+        val response = MockHttpServletResponse()
+
+        var capturedCorrelationId: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedCorrelationId = MDC.get("correlationId")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals("existing-correlation-id", capturedCorrelationId)
+        assertEquals("existing-correlation-id", response.getHeader("X-Correlation-ID"))
+    }
+
+    @Test
+    fun `extracts userId from JWT`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        addJwtHeader(request, "user-123")
+        val response = MockHttpServletResponse()
+
+        var capturedUserId: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedUserId = MDC.get("userId")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals("user-123", capturedUserId)
+    }
+
+    @Test
+    fun `userId is null when no Authorization header`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        val response = MockHttpServletResponse()
+
+        var capturedUserId: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedUserId = MDC.get("userId")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(capturedUserId)
+    }
+
+    @Test
+    fun `cleans up MDC after request`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        request.addHeader("X-Correlation-ID", "test-id")
+        addJwtHeader(request, "user-456")
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, filterChain)
+
+        assertNull(MDC.get("correlationId"))
+        assertNull(MDC.get("userId"))
+        assertNull(MDC.get("module"))
+    }
+
+    @Test
+    fun `extracts module from request path`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/locations")
+        val response = MockHttpServletResponse()
+
+        var capturedModule: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedModule = MDC.get("module")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals("locations", capturedModule)
+    }
+
+    @Test
+    fun `extracts module from admin path`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/admin/coaches")
+        val response = MockHttpServletResponse()
+
+        var capturedModule: String? = null
+        val chain = FilterChain { _, _ ->
+            capturedModule = MDC.get("module")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        assertEquals("coaches", capturedModule)
+    }
+
+    private fun addJwtHeader(request: MockHttpServletRequest, subject: String) {
+        val header = """{"alg":"RS256"}"""
+        val payload = """{"sub":"$subject"}"""
+        val headerB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(header.toByteArray())
+        val payloadB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(payload.toByteArray())
+        request.addHeader("Authorization", "Bearer $headerB64.$payloadB64.signature")
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/ExceptionLoggingAspectTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/ExceptionLoggingAspectTest.kt
@@ -1,0 +1,84 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.internal.aspect.ExceptionLoggingAspect
+import io.mockk.every
+import io.mockk.mockk
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.Signature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+
+class ExceptionLoggingAspectTest {
+
+    private lateinit var aspect: ExceptionLoggingAspect
+
+    @BeforeEach
+    fun setup() {
+        aspect = ExceptionLoggingAspect()
+        MDC.clear()
+    }
+
+    private fun createJoinPoint(): JoinPoint {
+        val joinPoint = mockk<JoinPoint>()
+        val signature = mockk<Signature>()
+        val target = TestTarget()
+
+        every { joinPoint.signature } returns signature
+        every { signature.name } returns "someMethod"
+        every { joinPoint.target } returns target
+
+        return joinPoint
+    }
+
+    @Test
+    fun `logs business exception at WARN level`() {
+        MDC.put("correlationId", "test-corr-id")
+        MDC.put("userId", "user-1")
+
+        val joinPoint = createJoinPoint()
+        val exception = NotFoundException("Resource not found")
+
+        // Should not throw
+        aspect.logException(joinPoint, exception)
+    }
+
+    @Test
+    fun `logs infrastructure exception at ERROR level`() {
+        MDC.put("correlationId", "test-corr-id")
+
+        val joinPoint = createJoinPoint()
+        val exception = RuntimeException("Database connection failed")
+
+        aspect.logException(joinPoint, exception)
+    }
+
+    @Test
+    fun `logs IllegalArgumentException as business exception`() {
+        val joinPoint = createJoinPoint()
+        val exception = IllegalArgumentException("Invalid input")
+
+        aspect.logException(joinPoint, exception)
+    }
+
+    @Test
+    fun `logs IllegalStateException as business exception`() {
+        val joinPoint = createJoinPoint()
+        val exception = IllegalStateException("Invalid state")
+
+        aspect.logException(joinPoint, exception)
+    }
+
+    @Test
+    fun `handles missing MDC values gracefully`() {
+        val joinPoint = createJoinPoint()
+        val exception = RuntimeException("Some error")
+
+        // No MDC set - should use defaults
+        aspect.logException(joinPoint, exception)
+    }
+}
+
+private class TestTarget
+
+private class NotFoundException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/LoggingAspectTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/LoggingAspectTest.kt
@@ -1,0 +1,128 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.LogExecution
+import com.nickdferrara.fitify.logging.LogLevel
+import com.nickdferrara.fitify.logging.internal.aspect.LoggingAspect
+import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
+import com.nickdferrara.fitify.logging.internal.service.SensitiveDataMasker
+import io.mockk.every
+import io.mockk.mockk
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LoggingAspectTest {
+
+    private val properties = LoggingProperties()
+    private val sensitiveDataMasker = SensitiveDataMasker()
+    private lateinit var loggingAspect: LoggingAspect
+
+    @BeforeEach
+    fun setup() {
+        loggingAspect = LoggingAspect(properties, sensitiveDataMasker)
+    }
+
+    private fun createJoinPoint(
+        methodName: String = "testMethod",
+        args: Array<Any?> = emptyArray(),
+        result: Any? = "result",
+    ): ProceedingJoinPoint {
+        val joinPoint = mockk<ProceedingJoinPoint>()
+        val signature = mockk<MethodSignature>()
+        val target = TestService()
+
+        every { joinPoint.signature } returns signature
+        every { signature.name } returns methodName
+        every { joinPoint.target } returns target
+        every { joinPoint.args } returns args
+        every { joinPoint.proceed() } returns result
+
+        val method = TestService::class.java.getMethod("publicMethod")
+        every { signature.method } returns method
+
+        return joinPoint
+    }
+
+    @Test
+    fun `logAnnotatedMethod executes and returns result`() {
+        val joinPoint = createJoinPoint(result = "expected")
+        val annotation = LogExecution(level = LogLevel.INFO)
+
+        val result = loggingAspect.logAnnotatedMethod(joinPoint, annotation)
+
+        assertEquals("expected", result)
+    }
+
+    @Test
+    fun `logAnnotatedMethod handles null result`() {
+        val joinPoint = createJoinPoint(result = null)
+        val annotation = LogExecution(level = LogLevel.DEBUG)
+
+        val result = loggingAspect.logAnnotatedMethod(joinPoint, annotation)
+
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `logAnnotatedMethod masks sensitive args`() {
+        data class SensitiveRequest(val password: String)
+
+        val joinPoint = createJoinPoint(args = arrayOf(SensitiveRequest("secret")))
+        val annotation = LogExecution(level = LogLevel.INFO, includeArgs = true)
+
+        val result = loggingAspect.logAnnotatedMethod(joinPoint, annotation)
+
+        // Should not throw, just verify it executes
+        assertEquals("result", result)
+    }
+
+    @Test
+    fun `logControllerMethod skips when controller logging disabled`() {
+        val disabledProperties = LoggingProperties(
+            aop = LoggingProperties.AopProperties(controllerLogging = false),
+        )
+        val aspect = LoggingAspect(disabledProperties, sensitiveDataMasker)
+        val joinPoint = createJoinPoint(result = "ok")
+
+        val result = aspect.logControllerMethod(joinPoint)
+
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `logServiceMethod skips when service logging disabled`() {
+        val disabledProperties = LoggingProperties(
+            aop = LoggingProperties.AopProperties(serviceLogging = false),
+        )
+        val aspect = LoggingAspect(disabledProperties, sensitiveDataMasker)
+        val joinPoint = createJoinPoint(result = "ok")
+
+        val result = aspect.logServiceMethod(joinPoint)
+
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `logControllerMethod executes when enabled`() {
+        val joinPoint = createJoinPoint(result = "controller-result")
+
+        val result = loggingAspect.logControllerMethod(joinPoint)
+
+        assertEquals("controller-result", result)
+    }
+
+    @Test
+    fun `logServiceMethod executes when enabled`() {
+        val joinPoint = createJoinPoint(result = "service-result")
+
+        val result = loggingAspect.logServiceMethod(joinPoint)
+
+        assertEquals("service-result", result)
+    }
+}
+
+class TestService {
+    fun publicMethod(): String = "test"
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/SensitiveDataMaskerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/SensitiveDataMaskerTest.kt
@@ -1,0 +1,108 @@
+package com.nickdferrara.fitify.logging.internal
+
+import com.nickdferrara.fitify.logging.Sensitive
+import com.nickdferrara.fitify.logging.internal.service.SensitiveDataMasker
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SensitiveDataMaskerTest {
+
+    private val masker = SensitiveDataMasker()
+
+    data class LoginRequest(
+        val email: String,
+        val password: String,
+    )
+
+    data class TokenData(
+        val userId: String,
+        val token: String,
+    )
+
+    data class PaymentInfo(
+        val amount: Long,
+        val creditCardNumber: String,
+        val ssn: String,
+    )
+
+    data class SafeData(
+        val name: String,
+        val age: Int,
+    )
+
+    data class AnnotatedData(
+        val name: String,
+        @field:Sensitive
+        val internalCode: String,
+    )
+
+    @Test
+    fun `masks password fields`() {
+        val result = masker.maskArgs(arrayOf(LoginRequest("test@email.com", "secret123")))
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].contains("***MASKED***"))
+        assertTrue(result[0].contains("test@email.com"))
+        assertFalse(result[0].contains("secret123"))
+    }
+
+    @Test
+    fun `masks token fields`() {
+        val result = masker.maskArgs(arrayOf(TokenData("user-1", "jwt-abc-123")))
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].contains("***MASKED***"))
+        assertTrue(result[0].contains("user-1"))
+        assertFalse(result[0].contains("jwt-abc-123"))
+    }
+
+    @Test
+    fun `masks credit card and SSN fields`() {
+        val result = masker.maskArgs(arrayOf(PaymentInfo(1000, "4111111111111111", "123-45-6789")))
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].contains("amount=1000"))
+        assertFalse(result[0].contains("4111111111111111"))
+        assertFalse(result[0].contains("123-45-6789"))
+    }
+
+    @Test
+    fun `preserves non-sensitive fields`() {
+        val result = masker.maskArgs(arrayOf(SafeData("Alice", 30)))
+
+        assertEquals(1, result.size)
+        assertEquals("SafeData(name=Alice, age=30)", result[0])
+    }
+
+    @Test
+    fun `masks fields annotated with @Sensitive`() {
+        val result = masker.maskArgs(arrayOf(AnnotatedData("visible", "hidden-value")))
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].contains("name=visible"))
+        assertTrue(result[0].contains("***MASKED***"))
+        assertFalse(result[0].contains("hidden-value"))
+    }
+
+    @Test
+    fun `handles null arguments`() {
+        val result = masker.maskArgs(arrayOf(null))
+
+        assertEquals(1, result.size)
+        assertEquals("null", result[0])
+    }
+
+    @Test
+    fun `handles multiple arguments`() {
+        val result = masker.maskArgs(arrayOf(
+            SafeData("Bob", 25),
+            LoginRequest("bob@test.com", "pass"),
+        ))
+
+        assertEquals(2, result.size)
+        assertEquals("SafeData(name=Bob, age=25)", result[0])
+        assertTrue(result[1].contains("***MASKED***"))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `logging` Spring Modulith module (OPEN type) with AOP-based structured logging, correlation ID tracking, audit trail persistence, and sensitive data masking
- Introduces `logback-spring.xml` with human-readable console output (dev) and JSON structured output via LogstashEncoder (staging/prod)
- Adds Docker Compose `observability` profile with Loki, Promtail, and Grafana including 6 pre-provisioned dashboards

## Key Components

### Public Annotations & API
- `@LogExecution` — opt-in method logging with configurable level, args, result, timing
- `@Audit` — captures audit trail records (action, resourceType, resourceId)
- `@Sensitive` — field-level annotation to mask values in logs
- `LoggingApi` — public interface for querying audit logs

### Internal Infrastructure
- `CorrelationIdFilter` — generates/propagates `X-Correlation-ID`, extracts `userId` from JWT and `module` from request path into MDC
- `LoggingAspect` — auto-logs controllers at INFO and services at DEBUG; supports `@LogExecution` override
- `ExceptionLoggingAspect` — categorizes business exceptions (WARN) vs infrastructure exceptions (ERROR)
- `AuditAspect` — intercepts `@Audit` methods, extracts resource ID, persists audit records
- `SensitiveDataMasker` — redacts passwords, tokens, credit cards, SSN, and `@Sensitive` fields
- `MdcTaskDecorator` via `ThreadPoolTaskExecutorCustomizer` — propagates MDC across `@Async` boundaries
- `AuditLogController` — admin-only `GET /api/v1/admin/audit-logs` with filtering

### Observability Stack
- Loki (log aggregation, 90-day retention)
- Promtail (Docker service discovery, JSON pipeline with label extraction)
- Grafana (auto-provisioned datasource + 6 dashboards: operations overview, request tracing, auth/security, payments, notifications, scheduling)

## Test plan
- [x] `./gradlew build` passes (345 tests, 0 failures, JaCoCo verified)
- [x] `ModulithStructureTest` passes with 10 modules (added `logging`)
- [x] Unit tests for `CorrelationIdFilter`, `SensitiveDataMasker`, `LoggingAspect`, `ExceptionLoggingAspect`, `AuditAspect`, `AuditLogService`
- [x] Run with `dev` profile — verify colored console output with correlation IDs
- [x] Run with `prod` profile — verify JSON structured output
- [x] `docker compose --profile observability up` — verify Grafana at localhost:3000 with dashboards