### PR TITLE
feat: decouple email sending from SMTP via EmailTransport adapter pattern

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     // Notification
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("com.google.firebase:firebase-admin:9.4.3")
+    implementation("com.sendgrid:sendgrid-java:4.10.3")
 
     // Database
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/config/EmailTransportConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/config/EmailTransportConfig.kt
@@ -1,0 +1,34 @@
+package com.nickdferrara.fitify.notification.internal.config
+
+import com.nickdferrara.fitify.notification.internal.service.EmailTransport
+import com.nickdferrara.fitify.notification.internal.service.SendGridEmailTransportAdapter
+import com.nickdferrara.fitify.notification.internal.service.SmtpEmailTransportAdapter
+import com.sendgrid.SendGrid
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mail.javamail.JavaMailSender
+
+@Configuration
+internal class EmailTransportConfig {
+
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fitify.notification.email.provider"],
+        havingValue = "smtp",
+        matchIfMissing = true,
+    )
+    fun smtpEmailTransport(mailSender: JavaMailSender): EmailTransport =
+        SmtpEmailTransportAdapter(mailSender)
+
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fitify.notification.email.provider"],
+        havingValue = "sendgrid",
+    )
+    fun sendGridEmailTransport(
+        @Value("\${fitify.notification.sendgrid.api-key}") apiKey: String,
+    ): EmailTransport =
+        SendGridEmailTransportAdapter(SendGrid(apiKey))
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/config/NotificationProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/config/NotificationProperties.kt
@@ -6,4 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 internal data class NotificationProperties(
     val fromEmail: String,
     val fromName: String,
-)
+    val email: EmailProperties = EmailProperties(),
+) {
+    internal data class EmailProperties(
+        val provider: String = "smtp",
+    )
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/EmailChannelSender.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/EmailChannelSender.kt
@@ -2,33 +2,23 @@ package com.nickdferrara.fitify.notification.internal.service
 
 import com.nickdferrara.fitify.notification.internal.config.NotificationProperties
 import com.nickdferrara.fitify.notification.internal.entities.NotificationChannel
-import com.nickdferrara.fitify.notification.internal.exception.NotificationDeliveryException
-import jakarta.mail.internet.InternetAddress
-import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
 internal class EmailChannelSender(
-    private val mailSender: JavaMailSender,
+    private val emailTransport: EmailTransport,
     private val notificationProperties: NotificationProperties,
 ) : NotificationChannelSender {
 
     override fun send(userId: UUID, subject: String, body: String, payload: Map<String, String>) {
         val recipientEmail = payload["email"] ?: return
 
-        try {
-            val message = mailSender.createMimeMessage()
-            val helper = MimeMessageHelper(message, true, "UTF-8")
-            helper.setFrom(InternetAddress(notificationProperties.fromEmail, notificationProperties.fromName))
-            helper.setTo(recipientEmail)
-            helper.setSubject(subject)
-            helper.setText(body, true)
-            mailSender.send(message)
-        } catch (ex: Exception) {
-            throw NotificationDeliveryException("Failed to send email to $recipientEmail", ex)
-        }
+        val from = EmailAddress(
+            email = notificationProperties.fromEmail,
+            name = notificationProperties.fromName,
+        )
+        emailTransport.send(from, recipientEmail, subject, body)
     }
 
     override fun supports(channel: NotificationChannel): Boolean =

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/EmailTransport.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/EmailTransport.kt
@@ -1,0 +1,7 @@
+package com.nickdferrara.fitify.notification.internal.service
+
+internal interface EmailTransport {
+    fun send(from: EmailAddress, to: String, subject: String, htmlBody: String)
+}
+
+internal data class EmailAddress(val email: String, val name: String)

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/SendGridEmailTransportAdapter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/SendGridEmailTransportAdapter.kt
@@ -1,0 +1,42 @@
+package com.nickdferrara.fitify.notification.internal.service
+
+import com.nickdferrara.fitify.notification.internal.exception.NotificationDeliveryException
+import com.sendgrid.Method
+import com.sendgrid.Request
+import com.sendgrid.SendGrid
+import com.sendgrid.helpers.mail.Mail
+import com.sendgrid.helpers.mail.objects.Content
+import com.sendgrid.helpers.mail.objects.Email
+
+internal class SendGridEmailTransportAdapter(
+    private val sendGrid: SendGrid,
+) : EmailTransport {
+
+    override fun send(from: EmailAddress, to: String, subject: String, htmlBody: String) {
+        try {
+            val mail = Mail(
+                Email(from.email, from.name),
+                subject,
+                Email(to),
+                Content("text/html", htmlBody),
+            )
+
+            val request = Request().apply {
+                method = Method.POST
+                endpoint = "mail/send"
+                body = mail.build()
+            }
+
+            val response = sendGrid.api(request)
+            if (response.statusCode !in 200..299) {
+                throw NotificationDeliveryException(
+                    "SendGrid returned status ${response.statusCode} for email to $to"
+                )
+            }
+        } catch (ex: NotificationDeliveryException) {
+            throw ex
+        } catch (ex: Exception) {
+            throw NotificationDeliveryException("Failed to send email via SendGrid to $to", ex)
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/SmtpEmailTransportAdapter.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/SmtpEmailTransportAdapter.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.fitify.notification.internal.service
+
+import com.nickdferrara.fitify.notification.internal.exception.NotificationDeliveryException
+import jakarta.mail.internet.InternetAddress
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+
+internal class SmtpEmailTransportAdapter(
+    private val mailSender: JavaMailSender,
+) : EmailTransport {
+
+    override fun send(from: EmailAddress, to: String, subject: String, htmlBody: String) {
+        try {
+            val message = mailSender.createMimeMessage()
+            val helper = MimeMessageHelper(message, true, "UTF-8")
+            helper.setFrom(InternetAddress(from.email, from.name))
+            helper.setTo(to)
+            helper.setSubject(subject)
+            helper.setText(htmlBody, true)
+            mailSender.send(message)
+        } catch (ex: Exception) {
+            throw NotificationDeliveryException("Failed to send email to $to", ex)
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,8 @@ fitify:
   notification:
     from-email: noreply@fitify.local
     from-name: Fitify Dev
+    email:
+      provider: smtp
   firebase:
     service-account-path: ""
   keycloak:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,10 @@ fitify:
   notification:
     from-email: ${NOTIFICATION_FROM_EMAIL:noreply@fitify.com}
     from-name: ${NOTIFICATION_FROM_NAME:Fitify}
+    email:
+      provider: ${EMAIL_PROVIDER:smtp}
+    sendgrid:
+      api-key: ${SENDGRID_API_KEY:}
   firebase:
     service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}
   keycloak:

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/EmailChannelSenderTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/EmailChannelSenderTest.kt
@@ -1,0 +1,68 @@
+package com.nickdferrara.fitify.notification.internal
+
+import com.nickdferrara.fitify.notification.internal.config.NotificationProperties
+import com.nickdferrara.fitify.notification.internal.entities.NotificationChannel
+import com.nickdferrara.fitify.notification.internal.service.EmailAddress
+import com.nickdferrara.fitify.notification.internal.service.EmailChannelSender
+import com.nickdferrara.fitify.notification.internal.service.EmailTransport
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class EmailChannelSenderTest {
+
+    private val emailTransport = mockk<EmailTransport>(relaxed = true)
+    private val properties = NotificationProperties(
+        fromEmail = "noreply@fitify.com",
+        fromName = "Fitify",
+    )
+    private val sender = EmailChannelSender(emailTransport, properties)
+
+    private val userId: UUID = UUID.randomUUID()
+
+    @Test
+    fun `send delegates to EmailTransport with correct EmailAddress`() {
+        val fromSlot = slot<EmailAddress>()
+        val toSlot = slot<String>()
+        val subjectSlot = slot<String>()
+        val bodySlot = slot<String>()
+
+        sender.send(userId, "Welcome", "<h1>Hi</h1>", mapOf("email" to "user@example.com"))
+
+        verify {
+            emailTransport.send(
+                capture(fromSlot),
+                capture(toSlot),
+                capture(subjectSlot),
+                capture(bodySlot),
+            )
+        }
+
+        assertEquals("noreply@fitify.com", fromSlot.captured.email)
+        assertEquals("Fitify", fromSlot.captured.name)
+        assertEquals("user@example.com", toSlot.captured)
+        assertEquals("Welcome", subjectSlot.captured)
+        assertEquals("<h1>Hi</h1>", bodySlot.captured)
+    }
+
+    @Test
+    fun `send is no-op when payload has no email`() {
+        sender.send(userId, "Subject", "Body", emptyMap())
+
+        verify(exactly = 0) { emailTransport.send(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `supports returns true for EMAIL channel`() {
+        assertTrue(sender.supports(NotificationChannel.EMAIL))
+    }
+
+    @Test
+    fun `supports returns false for PUSH channel`() {
+        assertEquals(false, sender.supports(NotificationChannel.PUSH))
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/SendGridEmailTransportAdapterTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/SendGridEmailTransportAdapterTest.kt
@@ -1,0 +1,53 @@
+package com.nickdferrara.fitify.notification.internal
+
+import com.nickdferrara.fitify.notification.internal.exception.NotificationDeliveryException
+import com.nickdferrara.fitify.notification.internal.service.EmailAddress
+import com.nickdferrara.fitify.notification.internal.service.SendGridEmailTransportAdapter
+import com.sendgrid.Request
+import com.sendgrid.Response
+import com.sendgrid.SendGrid
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+
+class SendGridEmailTransportAdapterTest {
+
+    private val sendGrid = mockk<SendGrid>()
+    private val adapter = SendGridEmailTransportAdapter(sendGrid)
+
+    private val from = EmailAddress("noreply@fitify.com", "Fitify")
+
+    @Test
+    fun `send builds correct request and succeeds on 202`() {
+        val requestSlot = slot<Request>()
+        val response = Response().apply { statusCode = 202 }
+        every { sendGrid.api(capture(requestSlot)) } returns response
+
+        adapter.send(from, "user@example.com", "Welcome", "<h1>Hello</h1>")
+
+        assertEquals("mail/send", requestSlot.captured.endpoint)
+    }
+
+    @Test
+    fun `send throws NotificationDeliveryException on non-2xx status`() {
+        val response = Response().apply { statusCode = 403 }
+        every { sendGrid.api(any<Request>()) } returns response
+
+        assertThrows<NotificationDeliveryException> {
+            adapter.send(from, "user@example.com", "Welcome", "<h1>Hello</h1>")
+        }
+    }
+
+    @Test
+    fun `send wraps IOException in NotificationDeliveryException`() {
+        every { sendGrid.api(any<Request>()) } throws IOException("Connection refused")
+
+        assertThrows<NotificationDeliveryException> {
+            adapter.send(from, "user@example.com", "Welcome", "<h1>Hello</h1>")
+        }
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/SmtpEmailTransportAdapterTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/SmtpEmailTransportAdapterTest.kt
@@ -1,0 +1,44 @@
+package com.nickdferrara.fitify.notification.internal
+
+import com.nickdferrara.fitify.notification.internal.exception.NotificationDeliveryException
+import com.nickdferrara.fitify.notification.internal.service.EmailAddress
+import com.nickdferrara.fitify.notification.internal.service.SmtpEmailTransportAdapter
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.mail.internet.MimeMessage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.mail.MailSendException
+import org.springframework.mail.javamail.JavaMailSender
+
+class SmtpEmailTransportAdapterTest {
+
+    private val mailSender = mockk<JavaMailSender>()
+    private val adapter = SmtpEmailTransportAdapter(mailSender)
+
+    private val from = EmailAddress("noreply@fitify.com", "Fitify")
+
+    @Test
+    fun `send creates mime message and delegates to JavaMailSender`() {
+        val mimeMessage = mockk<MimeMessage>(relaxed = true)
+        every { mailSender.createMimeMessage() } returns mimeMessage
+        every { mailSender.send(mimeMessage) } returns Unit
+
+        adapter.send(from, "user@example.com", "Welcome", "<h1>Hello</h1>")
+
+        verify { mailSender.createMimeMessage() }
+        verify { mailSender.send(mimeMessage) }
+    }
+
+    @Test
+    fun `send wraps mail exception in NotificationDeliveryException`() {
+        val mimeMessage = mockk<MimeMessage>(relaxed = true)
+        every { mailSender.createMimeMessage() } returns mimeMessage
+        every { mailSender.send(mimeMessage) } throws MailSendException("SMTP error")
+
+        assertThrows<NotificationDeliveryException> {
+            adapter.send(from, "user@example.com", "Welcome", "<h1>Hello</h1>")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce an `EmailTransport` port interface with `SmtpEmailTransportAdapter` (existing SMTP logic) and `SendGridEmailTransportAdapter` (new SendGrid SDK) implementations
- Wire adapters via `@ConditionalOnProperty` on `fitify.notification.email.provider` — SMTP is the default (`matchIfMissing = true`), SendGrid activates with `EMAIL_PROVIDER=sendgrid`
- Refactor `EmailChannelSender` to delegate to `EmailTransport` instead of coupling directly to `JavaMailSender`

## Test plan
- [x] `SmtpEmailTransportAdapterTest` — verifies MimeMessage creation, `JavaMailSender.send()` delegation, and exception wrapping
- [x] `SendGridEmailTransportAdapterTest` — verifies correct Mail/Request construction, 2xx success handling, non-2xx and IOException error handling
- [x] `EmailChannelSenderTest` — verifies delegation with correct `EmailAddress`, no-op when payload missing email, channel support
- [x] Existing `NotificationServiceTest` continues to pass (mocks at `NotificationChannelSender` level)
- [x] Full `./gradlew build` passes