### PR TITLE
feat: streamline self-hosting setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,42 @@
+# ──────────────────────────────────────────────
+# Fitify – Environment Variables
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+# ──────────────────────────────────────────────
+
+# ── PostgreSQL ────────────────────────────────
 POSTGRES_DB=fitify
 POSTGRES_USER=fitify
 POSTGRES_PASSWORD=fitify
 
+# ── Keycloak Admin Console ────────────────────
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
 
+# ── Spring Profile ────────────────────────────
 SPRING_PROFILES_ACTIVE=dev
 
-STRIPE_API_KEY=sk_test_your_key_here
+# ── Keycloak Client (fitify-api) ──────────────
+KEYCLOAK_CLIENT_SECRET=fitify-dev-secret
+FITIFY_KEYCLOAK_SERVER_URL=http://localhost:8180  # use http://keycloak:8180 inside Docker
+
+# ── Encryption & Security ────────────────────
+ENCRYPTION_KEY=dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u    # Base64-encoded 32-byte key – CHANGE FOR PROD
+TOKEN_PEPPER=dev-pepper-value-change-in-prod         # random string – CHANGE FOR PROD
+
+# ── Stripe ────────────────────────────────────
+STRIPE_SECRET_KEY=sk_test_your_key_here
 STRIPE_WEBHOOK_SECRET=whsec_your_secret_here
+STRIPE_SUCCESS_URL=http://localhost:3000/subscription/success
+STRIPE_CANCEL_URL=http://localhost:3000/subscription/cancel
+
+# ── Email / SMTP ──────────────────────────────
+SMTP_HOST=localhost          # use "mailpit" inside Docker
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+NOTIFICATION_FROM_EMAIL=noreply@fitify.com
+NOTIFICATION_FROM_NAME=Fitify
+
+# ── Firebase (optional – push notifications) ──
+FIREBASE_SERVICE_ACCOUNT_PATH=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# Fitify
+
+Fitness platform backend built with **Kotlin**, **Spring Boot 3**, and **Spring Modulith**. Manages coaching, scheduling, subscriptions, locations, and identity through a modular monolith architecture.
+
+## Quick Start
+
+```bash
+git clone https://github.com/nickdferrara/server-springboot-fitify.git
+cd server-springboot-fitify
+cp .env.example .env          # edit .env with your Stripe keys, etc.
+docker compose up -d
+```
+
+The app will be available at `http://localhost:8080` once all services are healthy.
+
+### Default Credentials
+
+| Service          | URL                        | Username           | Password |
+|------------------|----------------------------|--------------------|----------|
+| Keycloak Admin   | http://localhost:8180      | `admin`            | `admin`  |
+| Fitify Admin     | (via API)                  | `admin@fitify.com` | `admin`  |
+| Mailpit Web UI   | http://localhost:8025      | —                  | —        |
+| Grafana          | http://localhost:3000      | `admin`            | `admin`  |
+
+## Architecture
+
+Fitify is a **modular monolith** using [Spring Modulith](https://spring.io/projects/spring-modulith) for module boundary enforcement.
+
+### Modules
+
+| Module         | Description                                         |
+|----------------|-----------------------------------------------------|
+| `admin`        | Admin-facing endpoints and business rules            |
+| `coaching`     | Coach assignment and management                      |
+| `identity`     | Authentication, registration, Keycloak integration   |
+| `location`     | Gym location management                              |
+| `logging`      | Centralized logging and observability AOP             |
+| `notification` | Email notifications (SMTP / SendGrid)                |
+| `scheduling`   | Session scheduling and availability                  |
+| `security`     | Rate limiting, token hashing, security utilities     |
+| `shared`       | Cross-cutting: encryption, domain errors, events     |
+| `subscription` | Stripe-based subscription and billing                |
+
+### Cross-Module Communication
+
+- **Public API interfaces** (`*Api`) for synchronous calls between modules
+- **Application events** (data classes in each module's public package) for async communication
+- Internal code lives under `internal/` subpackages and is not accessible to other modules
+
+## Environment Variables
+
+See [`.env.example`](.env.example) for all variables with descriptions. Key groups:
+
+| Variable                     | Description                                  | Default                     |
+|------------------------------|----------------------------------------------|-----------------------------|
+| `POSTGRES_DB`                | Database name                                | `fitify`                    |
+| `POSTGRES_USER`              | Database user                                | `fitify`                    |
+| `POSTGRES_PASSWORD`          | Database password                            | `fitify`                    |
+| `KEYCLOAK_ADMIN`             | Keycloak admin console username              | `admin`                     |
+| `KEYCLOAK_ADMIN_PASSWORD`    | Keycloak admin console password              | `admin`                     |
+| `SPRING_PROFILES_ACTIVE`     | Spring profile (`dev`, `prod`)               | `dev`                       |
+| `KEYCLOAK_CLIENT_SECRET`     | Keycloak `fitify-api` client secret          | `fitify-dev-secret`         |
+| `FITIFY_KEYCLOAK_SERVER_URL` | Keycloak base URL                            | `http://localhost:8180`     |
+| `ENCRYPTION_KEY`             | Base64-encoded 32-byte AES key               | test default                |
+| `TOKEN_PEPPER`               | Random string for token hashing              | dev default                 |
+| `STRIPE_SECRET_KEY`          | Stripe API secret key                        | placeholder                 |
+| `STRIPE_WEBHOOK_SECRET`      | Stripe webhook signing secret                | placeholder                 |
+| `SMTP_HOST`                  | SMTP server hostname                         | `localhost`                 |
+| `SMTP_PORT`                  | SMTP server port                             | `1025`                      |
+
+## Bare-Metal Development
+
+To run without Docker (requires local PostgreSQL and Keycloak):
+
+```bash
+# Start PostgreSQL on port 5432 and Keycloak on port 8180
+# Import the realm: use Keycloak admin UI or CLI to import infra/keycloak/fitify-realm.json
+
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+## Running Tests
+
+```bash
+./gradlew test
+```
+
+> **Note:** `FitifyApplicationTests` uses Testcontainers and requires Docker. It is skipped automatically when Docker is unavailable.
+
+## Observability
+
+Start the logging stack (Loki + Promtail + Grafana) alongside the app:
+
+```bash
+docker compose --profile observability up -d
+```
+
+Access Grafana at `http://localhost:3000` — Loki is pre-configured as a data source.
+
+## Keycloak Roles
+
+The realm export (`infra/keycloak/fitify-realm.json`) includes these roles:
+
+| Role             | Description                     |
+|------------------|---------------------------------|
+| `ADMIN`          | Full system administrator       |
+| `LOCATION_ADMIN` | Manages a single gym location   |
+| `COACH`          | Personal trainer / coach        |
+| `CLIENT`         | Gym member / client             |
+
+The `fitify-api` client uses `client_credentials` grant with `manage-users` and `view-users` permissions for programmatic user management.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
     container_name: fitify-keycloak
-    command: start-dev
+    command: start-dev --import-realm
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-fitify}
@@ -32,9 +32,26 @@ services:
       KC_HTTP_PORT: 8180
     ports:
       - "8180:8180"
+    volumes:
+      - ./infra/keycloak/fitify-realm.json:/opt/keycloak/data/import/fitify-realm.json:ro
     depends_on:
       postgres:
         condition: service_healthy
+    networks:
+      - fitify-network
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8180 && echo done"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: fitify-mailpit
+    ports:
+      - "8025:8025"
+      - "1025:1025"
     networks:
       - fitify-network
 
@@ -47,13 +64,28 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-fitify}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-fitify}
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://keycloak:8180/realms/fitify
+      FITIFY_KEYCLOAK_SERVER_URL: http://keycloak:8180
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET:-fitify-dev-secret}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u}
+      TOKEN_PEPPER: ${TOKEN_PEPPER:-dev-pepper-value-change-in-prod}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-sk_test_placeholder}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-whsec_placeholder}
+      STRIPE_SUCCESS_URL: ${STRIPE_SUCCESS_URL:-http://localhost:3000/subscription/success}
+      STRIPE_CANCEL_URL: ${STRIPE_CANCEL_URL:-http://localhost:3000/subscription/cancel}
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      NOTIFICATION_FROM_EMAIL: ${NOTIFICATION_FROM_EMAIL:-noreply@fitify.com}
+      NOTIFICATION_FROM_NAME: ${NOTIFICATION_FROM_NAME:-Fitify}
+      FIREBASE_SERVICE_ACCOUNT_PATH: ${FIREBASE_SERVICE_ACCOUNT_PATH:-}
     ports:
       - "8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
       keycloak:
-        condition: service_started
+        condition: service_healthy
     networks:
       - fitify-network
 

--- a/infra/keycloak/fitify-realm.json
+++ b/infra/keycloak/fitify-realm.json
@@ -1,0 +1,75 @@
+{
+  "realm": "fitify",
+  "enabled": true,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "sslRequired": "external",
+  "roles": {
+    "realm": [
+      {
+        "name": "ADMIN",
+        "description": "Full system administrator"
+      },
+      {
+        "name": "LOCATION_ADMIN",
+        "description": "Manages a single gym location"
+      },
+      {
+        "name": "COACH",
+        "description": "Personal trainer / coach"
+      },
+      {
+        "name": "CLIENT",
+        "description": "Gym member / client"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "fitify-api",
+      "name": "Fitify API",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "fitify-dev-secret",
+      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": false,
+      "authorizationServicesEnabled": false,
+      "fullScopeAllowed": true
+    }
+  ],
+  "users": [
+    {
+      "username": "admin@fitify.com",
+      "email": "admin@fitify.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "ADMIN"
+      ]
+    },
+    {
+      "username": "service-account-fitify-api",
+      "enabled": true,
+      "serviceAccountClientId": "fitify-api",
+      "clientRoles": {
+        "realm-management": [
+          "manage-users",
+          "view-users"
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/shared/internal/config/ProductionConfigValidator.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/shared/internal/config/ProductionConfigValidator.kt
@@ -1,0 +1,54 @@
+package com.nickdferrara.fitify.shared.internal.config
+
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Profile
+import org.springframework.context.event.EventListener
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("prod")
+internal class ProductionConfigValidator(
+    private val environment: Environment,
+) {
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun validate() {
+        val errors = mutableListOf<String>()
+
+        val encryptionKey = environment.getProperty("fitify.encryption.key", "")
+        if (encryptionKey == "dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u") {
+            errors.add("fitify.encryption.key is set to the test default — generate a unique Base64-encoded 32-byte key")
+        }
+
+        val tokenPepper = environment.getProperty("fitify.security.token-pepper", "")
+        if (tokenPepper.startsWith("dev-pepper")) {
+            errors.add("fitify.security.token-pepper is set to a dev default — use a unique random value")
+        }
+
+        val stripeSecretKey = environment.getProperty("fitify.stripe.secret-key", "")
+        if (stripeSecretKey.isBlank() || stripeSecretKey.contains("placeholder")) {
+            errors.add("fitify.stripe.secret-key is blank or a placeholder — set your live Stripe secret key")
+        }
+
+        val stripeWebhookSecret = environment.getProperty("fitify.stripe.webhook-secret", "")
+        if (stripeWebhookSecret.isBlank() || stripeWebhookSecret.contains("placeholder")) {
+            errors.add("fitify.stripe.webhook-secret is blank or a placeholder — set your Stripe webhook secret")
+        }
+
+        val keycloakSecret = environment.getProperty("fitify.keycloak.client-secret", "")
+        if (keycloakSecret == "change-me" || keycloakSecret == "fitify-dev-secret") {
+            errors.add("fitify.keycloak.client-secret is set to a dev default — use the secret from your Keycloak client")
+        }
+
+        if (errors.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Production configuration validation failed:")
+                errors.forEachIndexed { index, error ->
+                    appendLine("  ${index + 1}. $error")
+                }
+            }
+            throw IllegalStateException(message)
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,10 +22,7 @@ fitify:
   firebase:
     service-account-path: ""
   keycloak:
-    server-url: http://localhost:8180
-    realm: fitify
-    client-id: fitify-api
-    client-secret: dev-secret
+    client-secret: fitify-dev-secret
   stripe:
     secret-key: sk_test_dev_placeholder
     webhook-secret: whsec_dev_placeholder

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,10 +62,10 @@ fitify:
   firebase:
     service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}
   keycloak:
-    server-url: http://localhost:8180
+    server-url: ${FITIFY_KEYCLOAK_SERVER_URL:http://localhost:8180}
     realm: fitify
     client-id: fitify-api
-    client-secret: change-me
+    client-secret: ${KEYCLOAK_CLIENT_SECRET:change-me}
   stripe:
     secret-key: ${STRIPE_SECRET_KEY:sk_test_placeholder}
     webhook-secret: ${STRIPE_WEBHOOK_SECRET:whsec_placeholder}

--- a/src/test/kotlin/com/nickdferrara/fitify/shared/internal/config/ProductionConfigValidatorTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/shared/internal/config/ProductionConfigValidatorTest.kt
@@ -1,0 +1,102 @@
+package com.nickdferrara.fitify.shared.internal.config
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.core.env.Environment
+
+class ProductionConfigValidatorTest {
+
+    private fun environmentWith(overrides: Map<String, String> = emptyMap()): Environment {
+        val defaults = mapOf(
+            "fitify.encryption.key" to "cHJvZC1rZXktMzItYnl0ZXMtbG9uZy4u",
+            "fitify.security.token-pepper" to "prod-pepper-value",
+            "fitify.stripe.secret-key" to "sk_live_real_key",
+            "fitify.stripe.webhook-secret" to "whsec_real_secret",
+            "fitify.keycloak.client-secret" to "prod-keycloak-secret",
+        )
+        val merged = defaults + overrides
+        val env = mockk<Environment>()
+        merged.forEach { (key, value) ->
+            every { env.getProperty(key, "") } returns value
+        }
+        return env
+    }
+
+    @Test
+    fun `valid production config passes without error`() {
+        val validator = ProductionConfigValidator(environmentWith())
+        assertDoesNotThrow { validator.validate() }
+    }
+
+    @Test
+    fun `test default encryption key is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.encryption.key" to "dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u"))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("encryption.key"))
+    }
+
+    @Test
+    fun `dev token pepper is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.security.token-pepper" to "dev-pepper-value-change-in-prod"))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("token-pepper"))
+    }
+
+    @Test
+    fun `placeholder stripe secret key is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.stripe.secret-key" to "sk_test_placeholder"))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("stripe.secret-key"))
+    }
+
+    @Test
+    fun `blank stripe webhook secret is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.stripe.webhook-secret" to ""))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("stripe.webhook-secret"))
+    }
+
+    @Test
+    fun `change-me keycloak secret is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.keycloak.client-secret" to "change-me"))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("keycloak.client-secret"))
+    }
+
+    @Test
+    fun `fitify-dev-secret keycloak secret is rejected`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(mapOf("fitify.keycloak.client-secret" to "fitify-dev-secret"))
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("keycloak.client-secret"))
+    }
+
+    @Test
+    fun `multiple errors are reported together`() {
+        val validator = ProductionConfigValidator(
+            environmentWith(
+                mapOf(
+                    "fitify.encryption.key" to "dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u",
+                    "fitify.keycloak.client-secret" to "change-me",
+                )
+            )
+        )
+        val ex = assertThrows<IllegalStateException> { validator.validate() }
+        assert(ex.message!!.contains("1."))
+        assert(ex.message!!.contains("2."))
+    }
+}


### PR DESCRIPTION
## Summary

- Add Keycloak realm auto-import with pre-configured client, 4 roles, admin user, and service account so Keycloak is ready on first boot
- Add Mailpit service for local email capture, wire all ~20 env vars through `docker-compose.yml`, and add Keycloak healthcheck
- Externalize Keycloak config in `application.yml`, simplify `application-dev.yml`, expand `.env.example` with grouped variables
- Add `ProductionConfigValidator` that fails fast when prod secrets are still set to dev defaults
- Add `README.md` with quick start, architecture overview, env var reference, and dev setup instructions

Closes #33

## Test plan

- [x] `./gradlew test` passes (including new `ProductionConfigValidatorTest`)
- [x] `docker compose up -d` — all services start, Keycloak auto-imports realm
- [x] `http://localhost:8180` — `fitify` realm exists with roles and admin user
- [x] `http://localhost:8025` — Mailpit UI accessible
- [x] App starts at `http://localhost:8080` without errors