### PR TITLE
refactor: extract service interfaces for all modules

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleController.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.admin.internal.controller
 
-import com.nickdferrara.fitify.admin.internal.AdminService
+import com.nickdferrara.fitify.admin.internal.service.interfaces.AdminService
 import com.nickdferrara.fitify.admin.internal.dtos.request.UpdateBusinessRuleRequest
 import com.nickdferrara.fitify.admin.internal.dtos.response.BusinessRuleResponse
 import jakarta.validation.Valid

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassController.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.admin.internal.controller
 
-import com.nickdferrara.fitify.admin.internal.AdminService
+import com.nickdferrara.fitify.admin.internal.service.interfaces.AdminService
 import com.nickdferrara.fitify.admin.internal.dtos.request.CreateClassRequest
 import com.nickdferrara.fitify.admin.internal.dtos.request.CreateRecurringScheduleRequest
 import com.nickdferrara.fitify.admin.internal.dtos.request.UpdateClassRequest

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminMetricsController.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.admin.internal.controller
 import com.nickdferrara.fitify.admin.internal.dtos.response.MetricResponse
 import com.nickdferrara.fitify.admin.internal.dtos.response.OverviewResponse
 import com.nickdferrara.fitify.admin.internal.entities.enums.Granularity
-import com.nickdferrara.fitify.admin.internal.service.MetricsService
+import com.nickdferrara.fitify.admin.internal.service.interfaces.MetricsService
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceImpl.kt
@@ -10,6 +10,7 @@ import com.nickdferrara.fitify.admin.internal.entities.enums.MetricType
 import com.nickdferrara.fitify.admin.internal.entities.MetricsSnapshot
 import com.nickdferrara.fitify.admin.internal.exceptions.InvalidMetricsQueryException
 import com.nickdferrara.fitify.admin.internal.repository.MetricsSnapshotRepository
+import com.nickdferrara.fitify.admin.internal.service.interfaces.MetricsService
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -19,26 +20,26 @@ import java.time.temporal.IsoFields
 import java.util.UUID
 
 @Service
-internal class MetricsService(
+internal class MetricsServiceImpl(
     private val metricsSnapshotRepository: MetricsSnapshotRepository,
-) {
+) : MetricsService {
 
-    fun getSignups(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+    override fun getSignups(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
         validateDateRange(from, to)
         return getMetric(MetricType.SIGNUPS, from, to, granularity, locationId)
     }
 
-    fun getCancellations(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+    override fun getCancellations(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
         validateDateRange(from, to)
         return getMetric(MetricType.CANCELLATIONS, from, to, granularity, locationId)
     }
 
-    fun getRevenue(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
+    override fun getRevenue(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse {
         validateDateRange(from, to)
         return getMetric(MetricType.REVENUE, from, to, granularity, locationId)
     }
 
-    fun getOverview(from: LocalDate, to: LocalDate, locationId: UUID?): OverviewResponse {
+    override fun getOverview(from: LocalDate, to: LocalDate, locationId: UUID?): OverviewResponse {
         validateDateRange(from, to)
         val metricTypes = listOf(
             MetricType.SIGNUPS,

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/interfaces/AdminService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/interfaces/AdminService.kt
@@ -1,0 +1,21 @@
+package com.nickdferrara.fitify.admin.internal.service.interfaces
+
+import com.nickdferrara.fitify.admin.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.admin.internal.dtos.request.CreateRecurringScheduleRequest
+import com.nickdferrara.fitify.admin.internal.dtos.request.UpdateBusinessRuleRequest
+import com.nickdferrara.fitify.admin.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.admin.internal.dtos.response.AdminClassResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.BusinessRuleResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.CancelClassResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.RecurringScheduleResponse
+import java.util.UUID
+
+internal interface AdminService {
+    fun createClass(locationId: UUID, request: CreateClassRequest): AdminClassResponse
+    fun updateClass(classId: UUID, request: UpdateClassRequest): AdminClassResponse
+    fun cancelClass(classId: UUID): CancelClassResponse
+    fun listClassesByLocation(locationId: UUID): List<AdminClassResponse>
+    fun createRecurringSchedule(locationId: UUID, request: CreateRecurringScheduleRequest): RecurringScheduleResponse
+    fun listBusinessRules(): List<BusinessRuleResponse>
+    fun updateBusinessRule(ruleKey: String, request: UpdateBusinessRuleRequest, updatedBy: String): BusinessRuleResponse
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/interfaces/MetricsService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/admin/internal/service/interfaces/MetricsService.kt
@@ -1,0 +1,14 @@
+package com.nickdferrara.fitify.admin.internal.service.interfaces
+
+import com.nickdferrara.fitify.admin.internal.dtos.response.MetricResponse
+import com.nickdferrara.fitify.admin.internal.dtos.response.OverviewResponse
+import com.nickdferrara.fitify.admin.internal.entities.enums.Granularity
+import java.time.LocalDate
+import java.util.UUID
+
+internal interface MetricsService {
+    fun getSignups(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse
+    fun getCancellations(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse
+    fun getRevenue(from: LocalDate, to: LocalDate, granularity: Granularity, locationId: UUID?): MetricResponse
+    fun getOverview(from: LocalDate, to: LocalDate, locationId: UUID?): OverviewResponse
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachController.kt
@@ -4,7 +4,7 @@ import com.nickdferrara.fitify.coaching.internal.dtos.request.AssignCoachLocatio
 import com.nickdferrara.fitify.coaching.internal.dtos.request.CreateCoachRequest
 import com.nickdferrara.fitify.coaching.internal.dtos.request.UpdateCoachRequest
 import com.nickdferrara.fitify.coaching.internal.dtos.response.CoachResponse
-import com.nickdferrara.fitify.coaching.internal.service.CoachingService
+import com.nickdferrara.fitify.coaching.internal.service.interfaces.CoachingService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminLocationCoachController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminLocationCoachController.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.coaching.internal.controller
 
 import com.nickdferrara.fitify.coaching.internal.dtos.response.CoachResponse
-import com.nickdferrara.fitify.coaching.internal.service.CoachingService
+import com.nickdferrara.fitify.coaching.internal.service.interfaces.CoachingService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/service/CoachingServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/service/CoachingServiceImpl.kt
@@ -24,10 +24,10 @@ import java.time.Instant
 import java.util.UUID
 
 @Service
-internal class CoachingService(
+internal class CoachingServiceImpl(
     private val coachRepository: CoachRepository,
     private val eventPublisher: ApplicationEventPublisher,
-) : CoachingApi {
+) : com.nickdferrara.fitify.coaching.internal.service.interfaces.CoachingService, CoachingApi {
 
     override fun findCoachById(id: UUID): Result<CoachSummary, DomainError> {
         val coach = coachRepository.findById(id).orElse(null)
@@ -43,18 +43,18 @@ internal class CoachingService(
         return coachRepository.findActiveCoachesByLocationId(locationId).map { it.toSummary() }
     }
 
-    fun findAll(): List<CoachResponse> {
+    override fun findAll(): List<CoachResponse> {
         return coachRepository.findAll().map { it.toResponse() }
     }
 
-    fun findById(id: UUID): CoachResponse {
+    override fun findById(id: UUID): CoachResponse {
         val coach = coachRepository.findById(id)
             .orElseThrow { CoachNotFoundException(id) }
         return coach.toResponse()
     }
 
     @Transactional
-    fun createCoach(request: CreateCoachRequest): CoachResponse {
+    override fun createCoach(request: CreateCoachRequest): CoachResponse {
         val coach = Coach(
             name = request.name,
             bio = request.bio,
@@ -86,7 +86,7 @@ internal class CoachingService(
     }
 
     @Transactional
-    fun updateCoach(id: UUID, request: UpdateCoachRequest): CoachResponse {
+    override fun updateCoach(id: UUID, request: UpdateCoachRequest): CoachResponse {
         val coach = coachRepository.findById(id)
             .orElseThrow { CoachNotFoundException(id) }
 
@@ -127,7 +127,7 @@ internal class CoachingService(
     }
 
     @Transactional
-    fun deactivateCoach(id: UUID) {
+    override fun deactivateCoach(id: UUID) {
         val coach = coachRepository.findById(id)
             .orElseThrow { CoachNotFoundException(id) }
 
@@ -143,7 +143,7 @@ internal class CoachingService(
     }
 
     @Transactional
-    fun assignLocations(coachId: UUID, request: AssignCoachLocationsRequest): CoachResponse {
+    override fun assignLocations(coachId: UUID, request: AssignCoachLocationsRequest): CoachResponse {
         val coach = coachRepository.findById(coachId)
             .orElseThrow { CoachNotFoundException(coachId) }
 
@@ -161,7 +161,7 @@ internal class CoachingService(
         return saved.toResponse()
     }
 
-    fun findCoachesByLocationId(locationId: UUID): List<CoachResponse> {
+    override fun findCoachesByLocationId(locationId: UUID): List<CoachResponse> {
         return coachRepository.findActiveCoachesByLocationId(locationId).map { it.toResponse() }
     }
 

--- a/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/service/interfaces/CoachingService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/coaching/internal/service/interfaces/CoachingService.kt
@@ -1,0 +1,17 @@
+package com.nickdferrara.fitify.coaching.internal.service.interfaces
+
+import com.nickdferrara.fitify.coaching.internal.dtos.request.AssignCoachLocationsRequest
+import com.nickdferrara.fitify.coaching.internal.dtos.request.CreateCoachRequest
+import com.nickdferrara.fitify.coaching.internal.dtos.request.UpdateCoachRequest
+import com.nickdferrara.fitify.coaching.internal.dtos.response.CoachResponse
+import java.util.UUID
+
+internal interface CoachingService {
+    fun findAll(): List<CoachResponse>
+    fun findById(id: UUID): CoachResponse
+    fun createCoach(request: CreateCoachRequest): CoachResponse
+    fun updateCoach(id: UUID, request: UpdateCoachRequest): CoachResponse
+    fun deactivateCoach(id: UUID)
+    fun assignLocations(coachId: UUID, request: AssignCoachLocationsRequest): CoachResponse
+    fun findCoachesByLocationId(locationId: UUID): List<CoachResponse>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/controller/AuthController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/controller/AuthController.kt
@@ -5,7 +5,7 @@ import com.nickdferrara.fitify.identity.internal.dtos.request.RegisterRequest
 import com.nickdferrara.fitify.identity.internal.dtos.request.ResetPasswordRequest
 import com.nickdferrara.fitify.identity.internal.dtos.response.MessageResponse
 import com.nickdferrara.fitify.identity.internal.dtos.response.RegisterResponse
-import com.nickdferrara.fitify.identity.internal.service.AuthService
+import com.nickdferrara.fitify.identity.internal.service.interfaces.AuthService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/controller/UserController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/controller/UserController.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.identity.internal.controller
 
-import com.nickdferrara.fitify.identity.internal.service.IdentityService
+import com.nickdferrara.fitify.identity.internal.service.interfaces.IdentityService
 import com.nickdferrara.fitify.identity.internal.dtos.request.UpdatePreferencesRequest
 import com.nickdferrara.fitify.identity.internal.dtos.response.UserPreferencesResponse
 import jakarta.validation.Valid

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/AuthServiceImpl.kt
@@ -28,13 +28,13 @@ import java.time.temporal.ChronoUnit
 import java.util.Base64
 
 @Service
-internal class AuthService(
+internal class AuthServiceImpl(
     private val userRepository: UserRepository,
     private val passwordResetTokenRepository: PasswordResetTokenRepository,
     private val identityProvider: IdentityProviderGateway,
     private val eventPublisher: ApplicationEventPublisher,
     @Value("\${fitify.security.token-pepper}") private val tokenPepper: String,
-) {
+) : com.nickdferrara.fitify.identity.internal.service.interfaces.AuthService {
 
     companion object {
         private val PASSWORD_PATTERN = Regex("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^a-zA-Z\\d]).{8,}$")
@@ -42,7 +42,7 @@ internal class AuthService(
     }
 
     @Transactional
-    fun register(request: RegisterRequest): RegisterResponse {
+    override fun register(request: RegisterRequest): RegisterResponse {
         validatePassword(request.password)
 
         if (userRepository.existsByEmail(request.email)) {
@@ -82,7 +82,7 @@ internal class AuthService(
     }
 
     @Transactional
-    fun forgotPassword(request: ForgotPasswordRequest): MessageResponse {
+    override fun forgotPassword(request: ForgotPasswordRequest): MessageResponse {
         val user = userRepository.findByEmail(request.email).orElse(null)
             ?: return MessageResponse("If an account exists with that email, a reset link has been sent.")
 
@@ -120,7 +120,7 @@ internal class AuthService(
     }
 
     @Transactional
-    fun resetPassword(request: ResetPasswordRequest): MessageResponse {
+    override fun resetPassword(request: ResetPasswordRequest): MessageResponse {
         validatePassword(request.newPassword)
 
         val tokenHash = hashToken(request.token)

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/IdentityServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/IdentityServiceImpl.kt
@@ -16,9 +16,9 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service
-internal class IdentityService(
+internal class IdentityServiceImpl(
     private val userRepository: UserRepository,
-) : IdentityApi {
+) : com.nickdferrara.fitify.identity.internal.service.interfaces.IdentityService, IdentityApi {
 
     override fun findUserById(id: UUID): Result<IdentityUserSummary, DomainError> {
         val user = userRepository.findById(id).orElse(null)
@@ -32,14 +32,14 @@ internal class IdentityService(
         return Result.Success(user.toSummary())
     }
 
-    fun getPreferences(keycloakId: String): UserPreferencesResponse {
+    override fun getPreferences(keycloakId: String): UserPreferencesResponse {
         val user = userRepository.findByKeycloakId(keycloakId)
             .orElseThrow { UserNotFoundException(keycloakId) }
         return user.toPreferencesResponse()
     }
 
     @Transactional
-    fun updatePreferences(keycloakId: String, request: UpdatePreferencesRequest): UserPreferencesResponse {
+    override fun updatePreferences(keycloakId: String, request: UpdatePreferencesRequest): UserPreferencesResponse {
         val user = userRepository.findByKeycloakId(keycloakId)
             .orElseThrow { UserNotFoundException(keycloakId) }
 

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/interfaces/AuthService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/interfaces/AuthService.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.fitify.identity.internal.service.interfaces
+
+import com.nickdferrara.fitify.identity.internal.dtos.request.ForgotPasswordRequest
+import com.nickdferrara.fitify.identity.internal.dtos.request.RegisterRequest
+import com.nickdferrara.fitify.identity.internal.dtos.request.ResetPasswordRequest
+import com.nickdferrara.fitify.identity.internal.dtos.response.MessageResponse
+import com.nickdferrara.fitify.identity.internal.dtos.response.RegisterResponse
+
+internal interface AuthService {
+    fun register(request: RegisterRequest): RegisterResponse
+    fun forgotPassword(request: ForgotPasswordRequest): MessageResponse
+    fun resetPassword(request: ResetPasswordRequest): MessageResponse
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/interfaces/IdentityService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/service/interfaces/IdentityService.kt
@@ -1,0 +1,9 @@
+package com.nickdferrara.fitify.identity.internal.service.interfaces
+
+import com.nickdferrara.fitify.identity.internal.dtos.request.UpdatePreferencesRequest
+import com.nickdferrara.fitify.identity.internal.dtos.response.UserPreferencesResponse
+
+internal interface IdentityService {
+    fun getPreferences(keycloakId: String): UserPreferencesResponse
+    fun updatePreferences(keycloakId: String, request: UpdatePreferencesRequest): UserPreferencesResponse
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationController.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.location.internal.controller
 import com.nickdferrara.fitify.location.internal.dtos.request.CreateLocationRequest
 import com.nickdferrara.fitify.location.internal.dtos.request.UpdateLocationRequest
 import com.nickdferrara.fitify.location.internal.dtos.response.LocationResponse
-import com.nickdferrara.fitify.location.internal.service.LocationService
+import com.nickdferrara.fitify.location.internal.service.interfaces.LocationService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -37,7 +37,7 @@ internal class AdminLocationController(
     }
 
     @GetMapping("/{locationId}")
-    fun getLocation(@PathVariable locationId: UUID): ResponseEntity<LocationResponse> {
+    fun findLocation(@PathVariable locationId: UUID): ResponseEntity<LocationResponse> {
         return ResponseEntity.ok(locationService.findById(locationId))
     }
 

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/LocationController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/controller/LocationController.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.location.internal.controller
 
 import com.nickdferrara.fitify.location.internal.dtos.response.LocationResponse
-import com.nickdferrara.fitify.location.internal.service.LocationService
+import com.nickdferrara.fitify.location.internal.service.interfaces.LocationService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/service/LocationServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/service/LocationServiceImpl.kt
@@ -22,10 +22,10 @@ import java.time.Instant
 import java.util.UUID
 
 @Service
-internal class LocationService(
+internal class LocationServiceImpl(
     private val locationRepository: LocationRepository,
     private val eventPublisher: ApplicationEventPublisher,
-) : LocationApi {
+) : com.nickdferrara.fitify.location.internal.service.interfaces.LocationService, LocationApi {
 
     override fun findLocationById(id: UUID): Result<LocationSummary, DomainError> {
         val location = locationRepository.findById(id).orElse(null)
@@ -37,22 +37,22 @@ internal class LocationService(
         return locationRepository.findByActiveTrue().map { it.toSummary() }
     }
 
-    fun findAll(): List<LocationResponse> {
+    override fun findAll(): List<LocationResponse> {
         return locationRepository.findAll().map { it.toResponse() }
     }
 
-    fun findAllActive(): List<LocationResponse> {
+    override fun findAllActive(): List<LocationResponse> {
         return locationRepository.findByActiveTrue().map { it.toResponse() }
     }
 
-    fun findById(id: UUID): LocationResponse {
+    override fun findById(id: UUID): LocationResponse {
         val location = locationRepository.findById(id)
             .orElseThrow { LocationNotFoundException(id) }
         return location.toResponse()
     }
 
     @Transactional
-    fun createLocation(request: CreateLocationRequest): LocationResponse {
+    override fun createLocation(request: CreateLocationRequest): LocationResponse {
         val location = Location(
             name = request.name,
             address = request.address,
@@ -90,7 +90,7 @@ internal class LocationService(
     }
 
     @Transactional
-    fun updateLocation(id: UUID, request: UpdateLocationRequest): LocationResponse {
+    override fun updateLocation(id: UUID, request: UpdateLocationRequest): LocationResponse {
         val location = locationRepository.findById(id)
             .orElseThrow { LocationNotFoundException(id) }
 
@@ -135,7 +135,7 @@ internal class LocationService(
     }
 
     @Transactional
-    fun deactivateLocation(id: UUID) {
+    override fun deactivateLocation(id: UUID) {
         val location = locationRepository.findById(id)
             .orElseThrow { LocationNotFoundException(id) }
 

--- a/src/main/kotlin/com/nickdferrara/fitify/location/internal/service/interfaces/LocationService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/location/internal/service/interfaces/LocationService.kt
@@ -1,0 +1,15 @@
+package com.nickdferrara.fitify.location.internal.service.interfaces
+
+import com.nickdferrara.fitify.location.internal.dtos.request.CreateLocationRequest
+import com.nickdferrara.fitify.location.internal.dtos.request.UpdateLocationRequest
+import com.nickdferrara.fitify.location.internal.dtos.response.LocationResponse
+import java.util.UUID
+
+internal interface LocationService {
+    fun findAll(): List<LocationResponse>
+    fun findAllActive(): List<LocationResponse>
+    fun findById(id: UUID): LocationResponse
+    fun createLocation(request: CreateLocationRequest): LocationResponse
+    fun updateLocation(id: UUID, request: UpdateLocationRequest): LocationResponse
+    fun deactivateLocation(id: UUID)
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/AuditAspect.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/aspect/AuditAspect.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.logging.internal.aspect
 
 import com.nickdferrara.fitify.logging.Audit
 import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
-import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.interfaces.AuditLogService
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingConfig.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/config/LoggingConfig.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.logging.internal.config
 import com.nickdferrara.fitify.logging.internal.aspect.AuditAspect
 import com.nickdferrara.fitify.logging.internal.aspect.ExceptionLoggingAspect
 import com.nickdferrara.fitify.logging.internal.aspect.LoggingAspect
-import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.interfaces.AuditLogService
 import com.nickdferrara.fitify.logging.internal.util.SensitiveDataMasker
 import org.slf4j.MDC
 import org.springframework.boot.context.properties.EnableConfigurationProperties

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/controller/AuditLogController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/controller/AuditLogController.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.logging.internal.controller
 
 import com.nickdferrara.fitify.logging.AuditLogResponse
-import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.interfaces.AuditLogService
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/AuditLogServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/AuditLogServiceImpl.kt
@@ -10,12 +10,12 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 @Service
-internal class AuditLogService(
+internal class AuditLogServiceImpl(
     private val auditLogRepository: AuditLogRepository,
-) : LoggingApi {
+) : com.nickdferrara.fitify.logging.internal.service.interfaces.AuditLogService, LoggingApi {
 
     @Transactional
-    fun save(
+    override fun save(
         userId: String,
         action: String,
         module: String,

--- a/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/interfaces/AuditLogService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/logging/internal/service/interfaces/AuditLogService.kt
@@ -1,0 +1,24 @@
+package com.nickdferrara.fitify.logging.internal.service.interfaces
+
+import com.nickdferrara.fitify.logging.AuditLogResponse
+import java.time.Instant
+
+internal interface AuditLogService {
+    fun save(
+        userId: String,
+        action: String,
+        module: String,
+        resourceType: String,
+        resourceId: String?,
+        details: String?,
+        ipAddress: String?,
+    )
+
+    fun queryAuditLogs(
+        userId: String?,
+        action: String?,
+        module: String?,
+        from: Instant?,
+        to: Instant?,
+    ): List<AuditLogResponse>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/controller/DeviceTokenController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/controller/DeviceTokenController.kt
@@ -4,7 +4,7 @@ import com.nickdferrara.fitify.notification.internal.dtos.request.RegisterDevice
 import com.nickdferrara.fitify.notification.internal.dtos.response.DeviceTokenResponse
 import com.nickdferrara.fitify.notification.internal.dtos.response.NotificationLogResponse
 import com.nickdferrara.fitify.notification.internal.extensions.toResponse
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/listener/NotificationEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/listener/NotificationEventListener.kt
@@ -5,7 +5,7 @@ import com.nickdferrara.fitify.identity.UserRegisteredEvent
 import com.nickdferrara.fitify.location.LocationDeactivatedEvent
 import com.nickdferrara.fitify.location.LocationUpdatedEvent
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayloadFactory
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService
 import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
 import com.nickdferrara.fitify.scheduling.ClassBookedEvent
 import com.nickdferrara.fitify.scheduling.ClassFullEvent

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/NotificationServiceImpl.kt
@@ -2,7 +2,6 @@ package com.nickdferrara.fitify.notification.internal.service
 
 import com.nickdferrara.fitify.notification.internal.adapter.interfaces.NotificationChannelSender
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayload
-import com.nickdferrara.fitify.notification.internal.factory.NotificationPayloadFactory
 import com.nickdferrara.fitify.notification.NotificationApi
 import com.nickdferrara.fitify.notification.NotificationFailedEvent
 import com.nickdferrara.fitify.notification.NotificationSentEvent
@@ -20,18 +19,17 @@ import java.time.Instant
 import java.util.UUID
 
 @Service
-internal class NotificationService(
+internal class NotificationServiceImpl(
     private val notificationLogRepository: NotificationLogRepository,
     private val deviceTokenRepository: DeviceTokenRepository,
     private val channelSenders: List<NotificationChannelSender>,
-    private val payloadFactory: NotificationPayloadFactory,
     private val eventPublisher: ApplicationEventPublisher,
-) : NotificationApi {
+) : com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService, NotificationApi {
 
-    private val logger = LoggerFactory.getLogger(NotificationService::class.java)
+    private val logger = LoggerFactory.getLogger(NotificationServiceImpl::class.java)
 
     @Async("notificationExecutor")
-    fun sendNotification(userId: UUID, eventType: String, payload: NotificationPayload) {
+    override fun sendNotification(userId: UUID, eventType: String, payload: NotificationPayload) {
         for (channel in payload.channels) {
             val sender = channelSenders.find { it.supports(channel) }
             if (sender == null) {
@@ -97,6 +95,6 @@ internal class NotificationService(
         deviceTokenRepository.delete(deviceToken)
     }
 
-    fun getNotificationHistory(userId: UUID) =
+    override fun getNotificationHistory(userId: UUID) =
         notificationLogRepository.findByUserId(userId)
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/interfaces/NotificationService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/notification/internal/service/interfaces/NotificationService.kt
@@ -1,0 +1,12 @@
+package com.nickdferrara.fitify.notification.internal.service.interfaces
+
+import com.nickdferrara.fitify.notification.internal.entities.NotificationLog
+import com.nickdferrara.fitify.notification.internal.factory.NotificationPayload
+import java.util.UUID
+
+internal interface NotificationService {
+    fun sendNotification(userId: UUID, eventType: String, payload: NotificationPayload)
+    fun registerDeviceToken(userId: UUID, token: String, deviceType: String)
+    fun removeDeviceToken(userId: UUID, token: String)
+    fun getNotificationHistory(userId: UUID): List<NotificationLog>
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.scheduling.internal.controller
 
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.scheduling.internal.controller
 
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListener.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.scheduling.internal.listener
 
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
 import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/interfaces/SchedulingService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/interfaces/SchedulingService.kt
@@ -1,0 +1,35 @@
+package com.nickdferrara.fitify.scheduling.internal.service.interfaces
+
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
+import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.LocalDate
+import java.util.UUID
+
+internal interface SchedulingService {
+    var cancellationWindowHours: Long
+    var maxWaitlistSize: Int
+    var maxBookingsPerDay: Int
+
+    fun searchClasses(
+        date: LocalDate?,
+        classType: String?,
+        coachId: UUID?,
+        locationId: UUID?,
+        available: Boolean?,
+        pageable: Pageable,
+    ): Page<ClassResponse>
+
+    fun createClass(locationId: UUID, request: CreateClassRequest): ClassResponse
+    fun getClass(classId: UUID): ClassResponse
+    fun updateClass(classId: UUID, request: UpdateClassRequest): ClassResponse
+    fun cancelClassInternal(classId: UUID)
+    fun bookClass(classId: UUID, userId: UUID): BookClassResult
+    fun cancelBooking(classId: UUID, userId: UUID)
+    fun getUserWaitlistEntries(userId: UUID): List<WaitlistEntryResponse>
+    fun removeFromWaitlist(classId: UUID, userId: UUID)
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentController.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.security.internal.controller
 
 import com.nickdferrara.fitify.security.internal.dtos.request.AssignLocationAdminRequest
 import com.nickdferrara.fitify.security.internal.dtos.response.LocationAdminAssignmentResponse
-import com.nickdferrara.fitify.security.internal.service.LocationAdminService
+import com.nickdferrara.fitify.security.internal.service.interfaces.LocationAdminService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceImpl.kt
@@ -13,11 +13,11 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service("locationAdminService")
-internal class LocationAdminService(
+internal class LocationAdminServiceImpl(
     private val repository: LocationAdminAssignmentRepository,
-) : SecurityApi {
+) : com.nickdferrara.fitify.security.internal.service.interfaces.LocationAdminService, SecurityApi {
 
-    fun hasAccess(authentication: Authentication, locationId: UUID): Boolean {
+    override fun hasAccess(authentication: Authentication, locationId: UUID): Boolean {
         val authorities = authentication.authorities.map { it.authority }
 
         if (authorities.contains("ROLE_ADMIN")) return true
@@ -39,7 +39,7 @@ internal class LocationAdminService(
     }
 
     @Transactional
-    fun assignLocationAdmin(keycloakId: String, locationId: UUID): LocationAdminAssignmentResponse {
+    override fun assignLocationAdmin(keycloakId: String, locationId: UUID): LocationAdminAssignmentResponse {
         if (repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)) {
             throw AssignmentAlreadyExistsException(keycloakId, locationId)
         }
@@ -54,12 +54,12 @@ internal class LocationAdminService(
         return assignment.toResponse()
     }
 
-    fun getAssignments(keycloakId: String): List<LocationAdminAssignmentResponse> {
+    override fun getAssignments(keycloakId: String): List<LocationAdminAssignmentResponse> {
         return repository.findByKeycloakId(keycloakId).map { it.toResponse() }
     }
 
     @Transactional
-    fun removeAssignment(keycloakId: String, locationId: UUID) {
+    override fun removeAssignment(keycloakId: String, locationId: UUID) {
         if (!repository.existsByKeycloakIdAndLocationId(keycloakId, locationId)) {
             throw AssignmentNotFoundException(keycloakId, locationId)
         }

--- a/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/interfaces/LocationAdminService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/security/internal/service/interfaces/LocationAdminService.kt
@@ -1,0 +1,12 @@
+package com.nickdferrara.fitify.security.internal.service.interfaces
+
+import com.nickdferrara.fitify.security.internal.dtos.response.LocationAdminAssignmentResponse
+import org.springframework.security.core.Authentication
+import java.util.UUID
+
+internal interface LocationAdminService {
+    fun hasAccess(authentication: Authentication, locationId: UUID): Boolean
+    fun assignLocationAdmin(keycloakId: String, locationId: UUID): LocationAdminAssignmentResponse
+    fun getAssignments(keycloakId: String): List<LocationAdminAssignmentResponse>
+    fun removeAssignment(keycloakId: String, locationId: UUID)
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookController.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.subscription.internal.controller
 
 import com.nickdferrara.fitify.subscription.internal.config.StripeProperties
 import com.nickdferrara.fitify.subscription.internal.exception.InvalidWebhookSignatureException
-import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import com.nickdferrara.fitify.subscription.internal.service.interfaces.SubscriptionService
 import com.stripe.model.Event
 import com.stripe.model.Invoice
 import com.stripe.net.Webhook

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionController.kt
@@ -6,7 +6,7 @@ import com.nickdferrara.fitify.subscription.internal.dtos.response.BillingPortal
 import com.nickdferrara.fitify.subscription.internal.dtos.response.CheckoutResponse
 import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionPlanResponse
 import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionResponse
-import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import com.nickdferrara.fitify.subscription.internal.service.interfaces.SubscriptionService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/interfaces/SubscriptionService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/subscription/internal/service/interfaces/SubscriptionService.kt
@@ -1,0 +1,22 @@
+package com.nickdferrara.fitify.subscription.internal.service.interfaces
+
+import com.nickdferrara.fitify.subscription.internal.dtos.request.ChangePlanRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.request.CheckoutRequest
+import com.nickdferrara.fitify.subscription.internal.dtos.response.BillingPortalResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.CheckoutResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionPlanResponse
+import com.nickdferrara.fitify.subscription.internal.dtos.response.SubscriptionResponse
+import java.util.UUID
+
+internal interface SubscriptionService {
+    fun getAvailablePlans(): List<SubscriptionPlanResponse>
+    fun getCurrentSubscription(userId: UUID): SubscriptionResponse
+    fun createCheckoutSession(userId: UUID, request: CheckoutRequest): CheckoutResponse
+    fun cancelSubscription(userId: UUID): SubscriptionResponse
+    fun changePlan(userId: UUID, request: ChangePlanRequest): CheckoutResponse
+    fun createBillingPortalSession(userId: UUID): BillingPortalResponse
+    fun handleSubscriptionCreated(stripeSubscriptionId: String, customerId: String, metadata: Map<String, String>)
+    fun handleSubscriptionRenewed(stripeSubscriptionId: String, amountPaid: Long, paymentIntentId: String?)
+    fun handleSubscriptionExpired(stripeSubscriptionId: String)
+    fun handlePaymentFailed(stripeSubscriptionId: String, paymentIntentId: String?)
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/AdminServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/AdminServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nickdferrara.fitify.admin.internal
 
+import com.nickdferrara.fitify.admin.internal.service.AdminServiceImpl
 import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
 import com.nickdferrara.fitify.admin.internal.dtos.request.CreateClassRequest
 import com.nickdferrara.fitify.admin.internal.dtos.request.CreateRecurringScheduleRequest
@@ -50,7 +51,7 @@ class AdminServiceTest {
     private val recurringScheduleRepository = mockk<RecurringScheduleRepository>()
     private val businessRuleRepository = mockk<BusinessRuleRepository>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    private val service = AdminService(
+    private val service = AdminServiceImpl(
         schedulingApi, coachingApi, locationApi, recurringScheduleRepository,
         businessRuleRepository, eventPublisher,
     )

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminBusinessRuleControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.admin.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.admin.internal.AdminService
+import com.nickdferrara.fitify.admin.internal.service.interfaces.AdminService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/controller/AdminClassControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.admin.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.admin.internal.AdminService
+import com.nickdferrara.fitify.admin.internal.service.interfaces.AdminService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/admin/internal/service/MetricsServiceTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class MetricsServiceTest {
 
     private val repository = mockk<MetricsSnapshotRepository>()
-    private val service = MetricsService(repository)
+    private val service = MetricsServiceImpl(repository)
 
     private fun buildSnapshot(
         metricType: MetricType = MetricType.SIGNUPS,

--- a/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/CoachingEventListenerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/CoachingEventListenerTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.coaching.internal
 
 import com.nickdferrara.fitify.coaching.internal.listener.CoachingEventListener
-import com.nickdferrara.fitify.coaching.internal.service.CoachingService
+import com.nickdferrara.fitify.coaching.internal.service.interfaces.CoachingService
 import com.nickdferrara.fitify.location.LocationCreatedEvent
 import com.nickdferrara.fitify.location.LocationDeactivatedEvent
 import com.nickdferrara.fitify.location.LocationUpdatedEvent

--- a/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/CoachingServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/CoachingServiceTest.kt
@@ -12,7 +12,7 @@ import com.nickdferrara.fitify.coaching.internal.entities.CoachCertification
 import com.nickdferrara.fitify.coaching.internal.entities.CoachLocation
 import com.nickdferrara.fitify.coaching.internal.repository.CoachRepository
 import com.nickdferrara.fitify.coaching.internal.service.CoachNotFoundException
-import com.nickdferrara.fitify.coaching.internal.service.CoachingService
+import com.nickdferrara.fitify.coaching.internal.service.CoachingServiceImpl
 import com.nickdferrara.fitify.shared.NotFoundError
 import com.nickdferrara.fitify.shared.Result
 import io.mockk.every
@@ -35,7 +35,7 @@ class CoachingServiceTest {
 
     private val coachRepository = mockk<CoachRepository>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    private val coachingService = CoachingService(coachRepository, eventPublisher)
+    private val coachingService = CoachingServiceImpl(coachRepository, eventPublisher)
 
     private fun buildCoach(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/coaching/internal/controller/AdminCoachControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.coaching.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.coaching.internal.service.CoachingService
+import com.nickdferrara.fitify.coaching.internal.service.interfaces.CoachingService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/AuthServiceTest.kt
@@ -14,7 +14,7 @@ import com.nickdferrara.fitify.identity.internal.exception.WeakPasswordException
 import com.nickdferrara.fitify.identity.internal.gateway.IdentityProviderGateway
 import com.nickdferrara.fitify.identity.internal.repository.PasswordResetTokenRepository
 import com.nickdferrara.fitify.identity.internal.repository.UserRepository
-import com.nickdferrara.fitify.identity.internal.service.AuthService
+import com.nickdferrara.fitify.identity.internal.service.AuthServiceImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -37,7 +37,7 @@ class AuthServiceTest {
     private val identityProvider = mockk<IdentityProviderGateway>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
     private val tokenPepper = "test-pepper"
-    private val authService = AuthService(userRepository, passwordResetTokenRepository, identityProvider, eventPublisher, tokenPepper)
+    private val authService = AuthServiceImpl(userRepository, passwordResetTokenRepository, identityProvider, eventPublisher, tokenPepper)
 
     private fun buildUser(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/IdentityServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/IdentityServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nickdferrara.fitify.identity.internal
 
+import com.nickdferrara.fitify.identity.internal.service.IdentityServiceImpl
 import com.nickdferrara.fitify.identity.internal.dtos.request.UpdatePreferencesRequest
 import com.nickdferrara.fitify.identity.internal.entities.ThemePreference
 import com.nickdferrara.fitify.identity.internal.entities.User
@@ -19,7 +20,7 @@ import java.util.UUID
 class IdentityServiceTest {
 
     private val userRepository = mockk<UserRepository>()
-    private val identityService = IdentityService(userRepository)
+    private val identityService = IdentityServiceImpl(userRepository)
 
     private fun buildUser(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/controller/AuthControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/controller/AuthControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.identity.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.identity.internal.service.AuthService
+import com.nickdferrara.fitify.identity.internal.service.interfaces.AuthService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/location/internal/LocationServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/location/internal/LocationServiceTest.kt
@@ -10,7 +10,7 @@ import com.nickdferrara.fitify.location.internal.entities.Location
 import com.nickdferrara.fitify.location.internal.entities.LocationOperatingHours
 import com.nickdferrara.fitify.location.internal.repository.LocationRepository
 import com.nickdferrara.fitify.location.internal.service.LocationNotFoundException
-import com.nickdferrara.fitify.location.internal.service.LocationService
+import com.nickdferrara.fitify.location.internal.service.LocationServiceImpl
 import com.nickdferrara.fitify.shared.NotFoundError
 import com.nickdferrara.fitify.shared.Result
 import io.mockk.every
@@ -34,7 +34,7 @@ class LocationServiceTest {
 
     private val locationRepository = mockk<LocationRepository>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    private val locationService = LocationService(locationRepository, eventPublisher)
+    private val locationService = LocationServiceImpl(locationRepository, eventPublisher)
 
     private fun buildLocation(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/location/internal/controller/AdminLocationControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.location.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.location.internal.service.LocationService
+import com.nickdferrara.fitify.location.internal.service.interfaces.LocationService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditAspectTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditAspectTest.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.logging.internal
 import com.nickdferrara.fitify.logging.Audit
 import com.nickdferrara.fitify.logging.internal.aspect.AuditAspect
 import com.nickdferrara.fitify.logging.internal.config.LoggingProperties
-import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.interfaces.AuditLogService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditLogServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/logging/internal/AuditLogServiceTest.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.logging.internal
 
 import com.nickdferrara.fitify.logging.internal.entities.AuditLogEntity
 import com.nickdferrara.fitify.logging.internal.repository.AuditLogRepository
-import com.nickdferrara.fitify.logging.internal.service.AuditLogService
+import com.nickdferrara.fitify.logging.internal.service.AuditLogServiceImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -17,7 +17,7 @@ import java.util.UUID
 class AuditLogServiceTest {
 
     private val auditLogRepository = mockk<AuditLogRepository>(relaxed = true)
-    private val auditLogService = AuditLogService(auditLogRepository)
+    private val auditLogService = AuditLogServiceImpl(auditLogRepository)
 
     @Test
     fun `save persists audit log entity`() {

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/DeviceTokenControllerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/DeviceTokenControllerTest.kt
@@ -6,7 +6,7 @@ import com.nickdferrara.fitify.notification.internal.entities.NotificationChanne
 import com.nickdferrara.fitify.notification.internal.entities.NotificationLog
 import com.nickdferrara.fitify.notification.internal.entities.NotificationStatus
 import com.nickdferrara.fitify.notification.internal.exception.DeviceTokenNotFoundException
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/NotificationEventListenerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/NotificationEventListenerTest.kt
@@ -6,7 +6,7 @@ import com.nickdferrara.fitify.notification.internal.entities.NotificationChanne
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayload
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayloadFactory
 import com.nickdferrara.fitify.notification.internal.listener.NotificationEventListener
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService
 import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
 import com.nickdferrara.fitify.scheduling.ClassBookedEvent
 import com.nickdferrara.fitify.scheduling.ClassFullEvent

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/NotificationServiceTest.kt
@@ -13,7 +13,7 @@ import com.nickdferrara.fitify.notification.internal.repository.NotificationLogR
 import com.nickdferrara.fitify.notification.internal.adapter.interfaces.NotificationChannelSender
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayload
 import com.nickdferrara.fitify.notification.internal.factory.NotificationPayloadFactory
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.NotificationServiceImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -34,7 +34,7 @@ class NotificationServiceTest {
     private val payloadFactory = mockk<NotificationPayloadFactory>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
 
-    private val service = NotificationService(
+    private val service = NotificationServiceImpl(
         notificationLogRepository,
         deviceTokenRepository,
         listOf(emailSender, pushSender),

--- a/src/test/kotlin/com/nickdferrara/fitify/notification/internal/controller/DeviceTokenControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/notification/internal/controller/DeviceTokenControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.notification.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.notification.internal.service.NotificationService
+import com.nickdferrara.fitify.notification.internal.service.interfaces.NotificationService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingServiceTest.kt
@@ -22,7 +22,7 @@ import com.nickdferrara.fitify.scheduling.internal.exceptions.DailyBookingLimitE
 import com.nickdferrara.fitify.scheduling.internal.exceptions.FitnessClassNotFoundException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.ScheduleConflictException
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingServiceImpl
 import com.nickdferrara.fitify.scheduling.internal.exceptions.WaitlistEntryNotFoundException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.WaitlistFullException
 import com.nickdferrara.fitify.shared.NotFoundError
@@ -47,7 +47,7 @@ class SchedulingServiceTest {
     private val bookingRepository = mockk<BookingRepository>()
     private val waitlistEntryRepository = mockk<WaitlistEntryRepository>()
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    private val service = SchedulingService(
+    private val service = SchedulingServiceImpl(
         fitnessClassRepository, bookingRepository, waitlistEntryRepository, eventPublisher,
     )
 

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassControllerWebMvcTest.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.scheduling.internal.controller
 import com.nickdferrara.fitify.TestSecurityConfig
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListenerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListenerTest.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.scheduling.internal.listener
 
-import com.nickdferrara.fitify.scheduling.internal.service.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
 import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
 import io.mockk.mockk
 import io.mockk.verify

--- a/src/test/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/security/internal/controller/LocationAdminAssignmentControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.security.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.security.internal.service.LocationAdminService
+import com.nickdferrara.fitify.security.internal.service.interfaces.LocationAdminService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/security/internal/service/LocationAdminServiceTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 class LocationAdminServiceTest {
 
     private val repository = mockk<LocationAdminAssignmentRepository>()
-    private val service = LocationAdminService(repository)
+    private val service = LocationAdminServiceImpl(repository)
 
     private val locationId = UUID.randomUUID()
     private val keycloakId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookControllerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/subscription/internal/controller/StripeWebhookControllerTest.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.subscription.internal.controller
 
 import com.nickdferrara.fitify.subscription.internal.config.StripeProperties
 import com.nickdferrara.fitify.subscription.internal.exception.InvalidWebhookSignatureException
-import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import com.nickdferrara.fitify.subscription.internal.service.interfaces.SubscriptionService
 import com.stripe.model.Event
 import com.stripe.model.EventDataObjectDeserializer
 import com.stripe.model.Invoice

--- a/src/test/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionControllerValidationTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/subscription/internal/controller/SubscriptionControllerValidationTest.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.subscription.internal.controller
 
 import com.nickdferrara.fitify.TestSecurityConfig
-import com.nickdferrara.fitify.subscription.internal.service.SubscriptionService
+import com.nickdferrara.fitify.subscription.internal.service.interfaces.SubscriptionService
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
## Summary
- Introduce interface/implementation pattern across all 11 service classes by creating dedicated interfaces in `service/interfaces/` subpackages
- Rename all concrete service classes to `*ServiceImpl` and have them implement both the new internal interface and the existing `*Api` cross-module interface
- Update all controllers, listeners, aspects, configs, and tests to reference the appropriate interface or implementation

## Test plan
- [x] Verify `compileKotlin` passes successfully
- [x] Verify all tests pass (note: pre-existing test compilation errors exist on `main` in MetricsEventListenerTest, CoachingEventListenerTest, NotificationServiceTest, IdentityServiceTest, and FitnessClassRepositoryIntegrationTest — not introduced by this PR)