### PR TITLE
refactor: decompose SchedulingServiceImpl into single-responsibility services

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassController.kt
@@ -2,7 +2,7 @@ package com.nickdferrara.fitify.scheduling.internal.controller
 
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
@@ -22,7 +22,7 @@ import java.util.UUID
 @RestController
 @RequestMapping("/api/v1/classes")
 internal class ClassController(
-    private val schedulingService: SchedulingService,
+    private val schedulingCommandService: SchedulingCommandService,
 ) {
 
     @GetMapping
@@ -35,7 +35,7 @@ internal class ClassController(
         pageable: Pageable,
     ): ResponseEntity<Page<ClassResponse>> {
         return ResponseEntity.ok(
-            schedulingService.searchClasses(date, classType, coachId, locationId, available, pageable)
+            schedulingCommandService.searchClasses(date, classType, coachId, locationId, available, pageable)
         )
     }
 
@@ -45,7 +45,7 @@ internal class ClassController(
         @AuthenticationPrincipal jwt: Jwt,
     ): ResponseEntity<Any> {
         val userId = UUID.fromString(jwt.subject)
-        return when (val result = schedulingService.bookClass(classId, userId)) {
+        return when (val result = schedulingCommandService.bookClass(classId, userId)) {
             is BookClassResult.Booked -> ResponseEntity.status(HttpStatus.CREATED).body(result.booking)
             is BookClassResult.Waitlisted -> ResponseEntity.status(HttpStatus.ACCEPTED).body(result.waitlistEntry)
         }
@@ -57,7 +57,7 @@ internal class ClassController(
         @AuthenticationPrincipal jwt: Jwt,
     ): ResponseEntity<Void> {
         val userId = UUID.fromString(jwt.subject)
-        schedulingService.cancelBooking(classId, userId)
+        schedulingCommandService.cancelBooking(classId, userId)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/WaitlistController.kt
@@ -1,7 +1,7 @@
 package com.nickdferrara.fitify.scheduling.internal.controller
 
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
-import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @RestController
 internal class WaitlistController(
-    private val schedulingService: SchedulingService,
+    private val schedulingCommandService: SchedulingCommandService,
 ) {
 
     @GetMapping("/api/v1/users/me/waitlist")
@@ -21,7 +21,7 @@ internal class WaitlistController(
         @AuthenticationPrincipal jwt: Jwt,
     ): ResponseEntity<List<WaitlistEntryResponse>> {
         val userId = UUID.fromString(jwt.subject)
-        return ResponseEntity.ok(schedulingService.getUserWaitlistEntries(userId))
+        return ResponseEntity.ok(schedulingCommandService.getUserWaitlistEntries(userId))
     }
 
     @DeleteMapping("/api/v1/classes/{classId}/waitlist")
@@ -30,7 +30,7 @@ internal class WaitlistController(
         @AuthenticationPrincipal jwt: Jwt,
     ): ResponseEntity<Void> {
         val userId = UUID.fromString(jwt.subject)
-        schedulingService.removeFromWaitlist(classId, userId)
+        schedulingCommandService.removeFromWaitlist(classId, userId)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/extensions/FitnessClassExtensions.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/extensions/FitnessClassExtensions.kt
@@ -1,8 +1,38 @@
 package com.nickdferrara.fitify.scheduling.internal.extensions
 
+import com.nickdferrara.fitify.scheduling.ClassDetail
+import com.nickdferrara.fitify.scheduling.ClassSummary
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
 import com.nickdferrara.fitify.scheduling.internal.enums.BookingStatus
 import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+
+internal fun FitnessClass.toSummary() = ClassSummary(
+    id = id!!,
+    name = name,
+    description = description,
+    classType = classType,
+    startTime = startTime,
+    endTime = endTime,
+    locationId = locationId,
+    coachId = coachId,
+)
+
+internal fun FitnessClass.toDetail() = ClassDetail(
+    id = id!!,
+    name = name,
+    description = description,
+    classType = classType,
+    coachId = coachId,
+    room = room,
+    startTime = startTime,
+    endTime = endTime,
+    capacity = capacity,
+    locationId = locationId,
+    status = status.name,
+    enrolledCount = bookings.count { it.status == BookingStatus.CONFIRMED },
+    waitlistSize = waitlistEntries.size,
+    createdAt = createdAt!!,
+)
 
 internal fun FitnessClass.toResponse() = ClassResponse(
     id = id!!,

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListener.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListener.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.scheduling.internal.listener
 
-import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 
 @Component
 internal class BusinessRuleEventListener(
-    private val schedulingService: SchedulingService,
+    private val schedulingCommandService: SchedulingCommandService,
 ) {
 
     private val logger = LoggerFactory.getLogger(BusinessRuleEventListener::class.java)
@@ -17,15 +17,15 @@ internal class BusinessRuleEventListener(
     fun onBusinessRuleUpdated(event: BusinessRuleUpdatedEvent) {
         when (event.ruleKey) {
             "cancellation_window_hours" -> {
-                schedulingService.cancellationWindowHours = event.newValue.toLong()
+                schedulingCommandService.cancellationWindowHours = event.newValue.toLong()
                 logger.info("Updated cancellationWindowHours to {}", event.newValue)
             }
             "max_waitlist_size" -> {
-                schedulingService.maxWaitlistSize = event.newValue.toInt()
+                schedulingCommandService.maxWaitlistSize = event.newValue.toInt()
                 logger.info("Updated maxWaitlistSize to {}", event.newValue)
             }
             "max_bookings_per_user_per_day" -> {
-                schedulingService.maxBookingsPerDay = event.newValue.toInt()
+                schedulingCommandService.maxBookingsPerDay = event.newValue.toInt()
                 logger.info("Updated maxBookingsPerDay to {}", event.newValue)
             }
         }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingCommandServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingCommandServiceImpl.kt
@@ -1,6 +1,18 @@
 package com.nickdferrara.fitify.scheduling.internal.service
 
-import com.nickdferrara.fitify.coaching.CoachAssignedEvent
+import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
+import com.nickdferrara.fitify.scheduling.ClassBookedEvent
+import com.nickdferrara.fitify.scheduling.ClassFullEvent
+import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
+import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import com.nickdferrara.fitify.scheduling.internal.enums.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.enums.FitnessClassStatus
 import com.nickdferrara.fitify.scheduling.internal.exceptions.AlreadyBookedException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.BookingNotFoundException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.CancellationWindowClosedException
@@ -10,38 +22,13 @@ import com.nickdferrara.fitify.scheduling.internal.exceptions.FitnessClassNotFou
 import com.nickdferrara.fitify.scheduling.internal.exceptions.ScheduleConflictException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.WaitlistEntryNotFoundException
 import com.nickdferrara.fitify.scheduling.internal.exceptions.WaitlistFullException
-import com.nickdferrara.fitify.scheduling.BookingCancelledEvent
-import com.nickdferrara.fitify.scheduling.CancelClassResult
-import com.nickdferrara.fitify.scheduling.ClassBookedEvent
-import com.nickdferrara.fitify.scheduling.ClassCancelledEvent
-import com.nickdferrara.fitify.scheduling.ClassDetail
-import com.nickdferrara.fitify.scheduling.ClassFullEvent
-import com.nickdferrara.fitify.scheduling.ClassSummary
-import com.nickdferrara.fitify.scheduling.ClassUpdatedEvent
-import com.nickdferrara.fitify.scheduling.ClassUtilizationSummary
-import com.nickdferrara.fitify.scheduling.CreateClassCommand
-import com.nickdferrara.fitify.scheduling.SchedulingApi
-import com.nickdferrara.fitify.scheduling.UpdateClassCommand
-import com.nickdferrara.fitify.scheduling.WaitlistPromotedEvent
-import com.nickdferrara.fitify.scheduling.internal.dtos.request.CreateClassRequest
-import com.nickdferrara.fitify.scheduling.internal.dtos.request.UpdateClassRequest
-import com.nickdferrara.fitify.scheduling.internal.dtos.response.BookingResponse
-import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
-import com.nickdferrara.fitify.scheduling.internal.dtos.response.WaitlistEntryResponse
 import com.nickdferrara.fitify.scheduling.internal.extensions.toResponse
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.entities.Booking
-import com.nickdferrara.fitify.scheduling.internal.enums.BookingStatus
-import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
-import com.nickdferrara.fitify.scheduling.internal.enums.FitnessClassStatus
-import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
 import com.nickdferrara.fitify.scheduling.internal.repository.BookingRepository
 import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassRepository
-import com.nickdferrara.fitify.scheduling.internal.specifications.FitnessClassSpecifications
 import com.nickdferrara.fitify.scheduling.internal.repository.WaitlistEntryRepository
-import com.nickdferrara.fitify.shared.DomainError
-import com.nickdferrara.fitify.shared.NotFoundError
-import com.nickdferrara.fitify.shared.Result
+import com.nickdferrara.fitify.scheduling.internal.specifications.FitnessClassSpecifications
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -53,177 +40,17 @@ import java.time.ZoneOffset
 import java.util.UUID
 
 @Service
-internal class SchedulingServiceImpl(
+@Transactional
+internal class SchedulingCommandServiceImpl(
     private val fitnessClassRepository: FitnessClassRepository,
     private val bookingRepository: BookingRepository,
     private val waitlistEntryRepository: WaitlistEntryRepository,
     private val eventPublisher: ApplicationEventPublisher,
-) : com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService, SchedulingApi {
+) : SchedulingCommandService {
 
     override var cancellationWindowHours: Long = 24
     override var maxWaitlistSize: Int = 20
     override var maxBookingsPerDay: Int = 3
-
-    // --- Public API (cross-module) ---
-
-    override fun findClassById(id: UUID): Result<ClassSummary, DomainError> {
-        val fitnessClass = fitnessClassRepository.findById(id).orElse(null)
-            ?: return Result.Failure(NotFoundError("Class not found: $id"))
-        return Result.Success(fitnessClass.toSummary())
-    }
-
-    override fun findUpcomingClassesByLocationId(locationId: UUID): List<ClassSummary> {
-        return fitnessClassRepository
-            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
-            .map { it.toSummary() }
-    }
-
-    @Transactional
-    override fun createClass(locationId: UUID, command: CreateClassCommand): ClassDetail {
-        val fitnessClass = FitnessClass(
-            locationId = locationId,
-            name = command.name,
-            description = command.description,
-            classType = command.classType,
-            coachId = command.coachId,
-            room = command.room,
-            startTime = command.startTime,
-            endTime = command.endTime,
-            capacity = command.capacity,
-        )
-        return fitnessClassRepository.save(fitnessClass).toDetail()
-    }
-
-    @Transactional
-    override fun updateClass(classId: UUID, command: UpdateClassCommand): ClassDetail {
-        val fitnessClass = fitnessClassRepository.findById(classId)
-            .orElseThrow { FitnessClassNotFoundException(classId) }
-
-        val updatedFields = mutableListOf<String>()
-
-        command.name?.let { fitnessClass.name = it; updatedFields.add("name") }
-        command.description?.let { fitnessClass.description = it; updatedFields.add("description") }
-        command.classType?.let { fitnessClass.classType = it; updatedFields.add("classType") }
-        command.coachId?.let { fitnessClass.coachId = it; updatedFields.add("coachId") }
-        command.room?.let { fitnessClass.room = it; updatedFields.add("room") }
-        command.startTime?.let { fitnessClass.startTime = it; updatedFields.add("startTime") }
-        command.endTime?.let { fitnessClass.endTime = it; updatedFields.add("endTime") }
-        command.capacity?.let { fitnessClass.capacity = it; updatedFields.add("capacity") }
-
-        val saved = fitnessClassRepository.save(fitnessClass)
-
-        if ("coachId" in updatedFields && command.coachId != null) {
-            eventPublisher.publishEvent(
-                CoachAssignedEvent(
-                    coachId = command.coachId!!,
-                    classId = classId,
-                )
-            )
-        }
-
-        if (updatedFields.any { it in listOf("startTime", "endTime", "capacity") }) {
-            val affectedUserIds = bookingRepository
-                .findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
-                .map { it.userId }
-
-            eventPublisher.publishEvent(
-                ClassUpdatedEvent(
-                    classId = classId,
-                    className = fitnessClass.name,
-                    locationId = fitnessClass.locationId,
-                    updatedFields = updatedFields,
-                    affectedUserIds = affectedUserIds,
-                )
-            )
-        }
-
-        return saved.toDetail()
-    }
-
-    @Transactional
-    override fun cancelClass(classId: UUID): CancelClassResult {
-        val fitnessClass = fitnessClassRepository.findById(classId)
-            .orElseThrow { FitnessClassNotFoundException(classId) }
-
-        fitnessClass.status = FitnessClassStatus.CANCELLED
-
-        val confirmedBookings = bookingRepository
-            .findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
-        val affectedUserIds = confirmedBookings.map { it.userId }
-        confirmedBookings.forEach { booking ->
-            booking.status = BookingStatus.CANCELLED
-            booking.cancelledAt = Instant.now()
-            bookingRepository.save(booking)
-        }
-
-        val waitlistEntries = waitlistEntryRepository
-            .findByFitnessClassIdOrderByPositionAsc(classId)
-        val waitlistUserIds = waitlistEntries.map { it.userId }
-        waitlistEntryRepository.deleteAll(waitlistEntries)
-
-        fitnessClassRepository.save(fitnessClass)
-
-        eventPublisher.publishEvent(
-            ClassCancelledEvent(
-                classId = classId,
-                className = fitnessClass.name,
-                locationId = fitnessClass.locationId,
-                originalStartTime = fitnessClass.startTime,
-                affectedUserIds = affectedUserIds,
-                waitlistUserIds = waitlistUserIds,
-                cancelledAt = Instant.now(),
-            )
-        )
-
-        return CancelClassResult(
-            classId = classId,
-            className = fitnessClass.name,
-            affectedUserIds = affectedUserIds,
-            waitlistUserIds = waitlistUserIds,
-        )
-    }
-
-    override fun getClassDetail(classId: UUID): Result<ClassDetail, DomainError> {
-        val fitnessClass = fitnessClassRepository.findById(classId).orElse(null)
-            ?: return Result.Failure(NotFoundError("Class not found: $classId"))
-        return Result.Success(fitnessClass.toDetail())
-    }
-
-    override fun findClassesByLocationId(locationId: UUID): List<ClassDetail> {
-        return fitnessClassRepository
-            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
-            .map { it.toDetail() }
-    }
-
-    override fun findClassesByCoachIdAndTimeRange(
-        coachId: UUID,
-        startTime: Instant,
-        endTime: Instant,
-    ): List<ClassSummary> {
-        return fitnessClassRepository
-            .findByCoachIdAndTimeRange(coachId, startTime, endTime)
-            .map { it.toSummary() }
-    }
-
-    override fun getClassUtilizationByDateRange(start: Instant, end: Instant): List<ClassUtilizationSummary> {
-        return fitnessClassRepository.findWithBookingsByDateRange(start, end).map { fc ->
-            ClassUtilizationSummary(
-                classId = fc.id!!,
-                locationId = fc.locationId,
-                classType = fc.classType,
-                capacity = fc.capacity,
-                enrolledCount = fc.bookings.count { it.status == BookingStatus.CONFIRMED },
-            )
-        }
-    }
-
-    override fun countBookingCancellationsBetween(start: Instant, end: Instant, locationId: UUID?): Long {
-        return if (locationId != null) {
-            bookingRepository.countCancellationsBetweenAndLocationId(start, end, locationId)
-        } else {
-            bookingRepository.countCancellationsBetween(start, end)
-        }
-    }
 
     // --- Search ---
 
@@ -247,9 +74,8 @@ internal class SchedulingServiceImpl(
         return fitnessClassRepository.findAll(spec, pageable).map { it.toResponse() }
     }
 
-    // --- Internal CRUD (used by internal controllers) ---
+    // --- Internal CRUD ---
 
-    @Transactional
     override fun createClass(locationId: UUID, request: CreateClassRequest): ClassResponse {
         val fitnessClass = FitnessClass(
             locationId = locationId,
@@ -271,7 +97,6 @@ internal class SchedulingServiceImpl(
         return fitnessClass.toResponse()
     }
 
-    @Transactional
     override fun updateClass(classId: UUID, request: UpdateClassRequest): ClassResponse {
         val fitnessClass = fitnessClassRepository.findById(classId)
             .orElseThrow { FitnessClassNotFoundException(classId) }
@@ -288,7 +113,6 @@ internal class SchedulingServiceImpl(
         return fitnessClassRepository.save(fitnessClass).toResponse()
     }
 
-    @Transactional
     override fun cancelClassInternal(classId: UUID) {
         val fitnessClass = fitnessClassRepository.findById(classId)
             .orElseThrow { FitnessClassNotFoundException(classId) }
@@ -312,7 +136,6 @@ internal class SchedulingServiceImpl(
 
     // --- Booking ---
 
-    @Transactional
     override fun bookClass(classId: UUID, userId: UUID): BookClassResult {
         val fitnessClass = fitnessClassRepository.findById(classId)
             .orElseThrow { FitnessClassNotFoundException(classId) }
@@ -344,8 +167,6 @@ internal class SchedulingServiceImpl(
         if (dailyCount >= maxBookingsPerDay) {
             throw DailyBookingLimitExceededException(userId, maxBookingsPerDay)
         }
-
-        // TODO: Check subscription status when subscription module is implemented
 
         val confirmedCount = bookingRepository
             .countByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
@@ -398,7 +219,6 @@ internal class SchedulingServiceImpl(
         return BookClassResult.Waitlisted(savedEntry.toResponse())
     }
 
-    @Transactional
     override fun cancelBooking(classId: UUID, userId: UUID) {
         val booking = bookingRepository
             .findByFitnessClassIdAndUserIdAndStatus(classId, userId, BookingStatus.CONFIRMED)
@@ -433,7 +253,6 @@ internal class SchedulingServiceImpl(
             .map { it.toResponse() }
     }
 
-    @Transactional
     override fun removeFromWaitlist(classId: UUID, userId: UUID) {
         val entry = waitlistEntryRepository.findByFitnessClassIdAndUserId(classId, userId)
             ?: throw WaitlistEntryNotFoundException(classId, userId)
@@ -484,32 +303,4 @@ internal class SchedulingServiceImpl(
             return
         }
     }
-
-    private fun FitnessClass.toSummary() = ClassSummary(
-        id = id!!,
-        name = name,
-        description = description,
-        classType = classType,
-        startTime = startTime,
-        endTime = endTime,
-        locationId = locationId,
-        coachId = coachId,
-    )
-
-    private fun FitnessClass.toDetail() = ClassDetail(
-        id = id!!,
-        name = name,
-        description = description,
-        classType = classType,
-        coachId = coachId,
-        room = room,
-        startTime = startTime,
-        endTime = endTime,
-        capacity = capacity,
-        locationId = locationId,
-        status = status.name,
-        enrolledCount = bookings.count { it.status == BookingStatus.CONFIRMED },
-        waitlistSize = waitlistEntries.size,
-        createdAt = createdAt!!,
-    )
 }

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingQueryServiceImpl.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/SchedulingQueryServiceImpl.kt
@@ -1,0 +1,198 @@
+package com.nickdferrara.fitify.scheduling.internal.service
+
+import com.nickdferrara.fitify.coaching.CoachAssignedEvent
+import com.nickdferrara.fitify.scheduling.CancelClassResult
+import com.nickdferrara.fitify.scheduling.ClassCancelledEvent
+import com.nickdferrara.fitify.scheduling.ClassDetail
+import com.nickdferrara.fitify.scheduling.ClassSummary
+import com.nickdferrara.fitify.scheduling.ClassUpdatedEvent
+import com.nickdferrara.fitify.scheduling.ClassUtilizationSummary
+import com.nickdferrara.fitify.scheduling.CreateClassCommand
+import com.nickdferrara.fitify.scheduling.SchedulingApi
+import com.nickdferrara.fitify.scheduling.UpdateClassCommand
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.enums.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.enums.FitnessClassStatus
+import com.nickdferrara.fitify.scheduling.internal.exceptions.FitnessClassNotFoundException
+import com.nickdferrara.fitify.scheduling.internal.extensions.toDetail
+import com.nickdferrara.fitify.scheduling.internal.extensions.toSummary
+import com.nickdferrara.fitify.scheduling.internal.repository.BookingRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.WaitlistEntryRepository
+import com.nickdferrara.fitify.shared.DomainError
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+internal class SchedulingQueryServiceImpl(
+    private val fitnessClassRepository: FitnessClassRepository,
+    private val bookingRepository: BookingRepository,
+    private val waitlistEntryRepository: WaitlistEntryRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+) : SchedulingApi {
+
+    override fun findClassById(id: UUID): Result<ClassSummary, DomainError> {
+        val fitnessClass = fitnessClassRepository.findById(id).orElse(null)
+            ?: return Result.Failure(NotFoundError("Class not found: $id"))
+        return Result.Success(fitnessClass.toSummary())
+    }
+
+    override fun findUpcomingClassesByLocationId(locationId: UUID): List<ClassSummary> {
+        return fitnessClassRepository
+            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
+            .map { it.toSummary() }
+    }
+
+    @Transactional
+    override fun createClass(locationId: UUID, command: CreateClassCommand): ClassDetail {
+        val fitnessClass = FitnessClass(
+            locationId = locationId,
+            name = command.name,
+            description = command.description,
+            classType = command.classType,
+            coachId = command.coachId,
+            room = command.room,
+            startTime = command.startTime,
+            endTime = command.endTime,
+            capacity = command.capacity,
+        )
+        return fitnessClassRepository.save(fitnessClass).toDetail()
+    }
+
+    @Transactional
+    override fun updateClass(classId: UUID, command: UpdateClassCommand): ClassDetail {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+
+        val updatedFields = mutableListOf<String>()
+
+        command.name?.let { fitnessClass.name = it; updatedFields.add("name") }
+        command.description?.let { fitnessClass.description = it; updatedFields.add("description") }
+        command.classType?.let { fitnessClass.classType = it; updatedFields.add("classType") }
+        command.coachId?.let { fitnessClass.coachId = it; updatedFields.add("coachId") }
+        command.room?.let { fitnessClass.room = it; updatedFields.add("room") }
+        command.startTime?.let { fitnessClass.startTime = it; updatedFields.add("startTime") }
+        command.endTime?.let { fitnessClass.endTime = it; updatedFields.add("endTime") }
+        command.capacity?.let { fitnessClass.capacity = it; updatedFields.add("capacity") }
+
+        val saved = fitnessClassRepository.save(fitnessClass)
+
+        if ("coachId" in updatedFields && command.coachId != null) {
+            eventPublisher.publishEvent(
+                CoachAssignedEvent(
+                    coachId = command.coachId!!,
+                    classId = classId,
+                )
+            )
+        }
+
+        if (updatedFields.any { it in listOf("startTime", "endTime", "capacity") }) {
+            val affectedUserIds = bookingRepository
+                .findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
+                .map { it.userId }
+
+            eventPublisher.publishEvent(
+                ClassUpdatedEvent(
+                    classId = classId,
+                    className = fitnessClass.name,
+                    locationId = fitnessClass.locationId,
+                    updatedFields = updatedFields,
+                    affectedUserIds = affectedUserIds,
+                )
+            )
+        }
+
+        return saved.toDetail()
+    }
+
+    @Transactional
+    override fun cancelClass(classId: UUID): CancelClassResult {
+        val fitnessClass = fitnessClassRepository.findById(classId)
+            .orElseThrow { FitnessClassNotFoundException(classId) }
+
+        fitnessClass.status = FitnessClassStatus.CANCELLED
+
+        val confirmedBookings = bookingRepository
+            .findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED)
+        val affectedUserIds = confirmedBookings.map { it.userId }
+        confirmedBookings.forEach { booking ->
+            booking.status = BookingStatus.CANCELLED
+            booking.cancelledAt = Instant.now()
+            bookingRepository.save(booking)
+        }
+
+        val waitlistEntries = waitlistEntryRepository
+            .findByFitnessClassIdOrderByPositionAsc(classId)
+        val waitlistUserIds = waitlistEntries.map { it.userId }
+        waitlistEntryRepository.deleteAll(waitlistEntries)
+
+        fitnessClassRepository.save(fitnessClass)
+
+        eventPublisher.publishEvent(
+            ClassCancelledEvent(
+                classId = classId,
+                className = fitnessClass.name,
+                locationId = fitnessClass.locationId,
+                originalStartTime = fitnessClass.startTime,
+                affectedUserIds = affectedUserIds,
+                waitlistUserIds = waitlistUserIds,
+                cancelledAt = Instant.now(),
+            )
+        )
+
+        return CancelClassResult(
+            classId = classId,
+            className = fitnessClass.name,
+            affectedUserIds = affectedUserIds,
+            waitlistUserIds = waitlistUserIds,
+        )
+    }
+
+    override fun getClassDetail(classId: UUID): Result<ClassDetail, DomainError> {
+        val fitnessClass = fitnessClassRepository.findById(classId).orElse(null)
+            ?: return Result.Failure(NotFoundError("Class not found: $classId"))
+        return Result.Success(fitnessClass.toDetail())
+    }
+
+    override fun findClassesByLocationId(locationId: UUID): List<ClassDetail> {
+        return fitnessClassRepository
+            .findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, Instant.now())
+            .map { it.toDetail() }
+    }
+
+    override fun findClassesByCoachIdAndTimeRange(
+        coachId: UUID,
+        startTime: Instant,
+        endTime: Instant,
+    ): List<ClassSummary> {
+        return fitnessClassRepository
+            .findByCoachIdAndTimeRange(coachId, startTime, endTime)
+            .map { it.toSummary() }
+    }
+
+    override fun getClassUtilizationByDateRange(start: Instant, end: Instant): List<ClassUtilizationSummary> {
+        return fitnessClassRepository.findWithBookingsByDateRange(start, end).map { fc ->
+            ClassUtilizationSummary(
+                classId = fc.id!!,
+                locationId = fc.locationId,
+                classType = fc.classType,
+                capacity = fc.capacity,
+                enrolledCount = fc.bookings.count { it.status == BookingStatus.CONFIRMED },
+            )
+        }
+    }
+
+    override fun countBookingCancellationsBetween(start: Instant, end: Instant, locationId: UUID?): Long {
+        return if (locationId != null) {
+            bookingRepository.countCancellationsBetweenAndLocationId(start, end, locationId)
+        } else {
+            bookingRepository.countCancellationsBetween(start, end)
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/interfaces/SchedulingCommandService.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/scheduling/internal/service/interfaces/SchedulingCommandService.kt
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 import java.util.UUID
 
-internal interface SchedulingService {
+internal interface SchedulingCommandService {
     var cancellationWindowHours: Long
     var maxWaitlistSize: Int
     var maxBookingsPerDay: Int

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingQueryServiceTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/SchedulingQueryServiceTest.kt
@@ -1,0 +1,216 @@
+package com.nickdferrara.fitify.scheduling.internal
+
+import com.nickdferrara.fitify.scheduling.ClassCancelledEvent
+import com.nickdferrara.fitify.scheduling.internal.entities.Booking
+import com.nickdferrara.fitify.scheduling.internal.enums.BookingStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.FitnessClass
+import com.nickdferrara.fitify.scheduling.internal.enums.FitnessClassStatus
+import com.nickdferrara.fitify.scheduling.internal.entities.WaitlistEntry
+import com.nickdferrara.fitify.scheduling.internal.repository.BookingRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.FitnessClassRepository
+import com.nickdferrara.fitify.scheduling.internal.repository.WaitlistEntryRepository
+import com.nickdferrara.fitify.scheduling.internal.service.SchedulingQueryServiceImpl
+import com.nickdferrara.fitify.shared.NotFoundError
+import com.nickdferrara.fitify.shared.Result
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Optional
+import java.util.UUID
+
+class SchedulingQueryServiceTest {
+
+    private val fitnessClassRepository = mockk<FitnessClassRepository>()
+    private val bookingRepository = mockk<BookingRepository>()
+    private val waitlistEntryRepository = mockk<WaitlistEntryRepository>()
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    private val service = SchedulingQueryServiceImpl(
+        fitnessClassRepository, bookingRepository, waitlistEntryRepository, eventPublisher,
+    )
+
+    private val locationId: UUID = UUID.randomUUID()
+    private val coachId: UUID = UUID.randomUUID()
+    private val userId: UUID = UUID.randomUUID()
+
+    private fun buildFitnessClass(
+        id: UUID = UUID.randomUUID(),
+        name: String = "Morning Yoga",
+        classType: String = "yoga",
+        capacity: Int = 20,
+        status: FitnessClassStatus = FitnessClassStatus.ACTIVE,
+        startTime: Instant = Instant.now().plus(2, ChronoUnit.DAYS),
+        endTime: Instant = Instant.now().plus(2, ChronoUnit.DAYS).plus(1, ChronoUnit.HOURS),
+    ) = FitnessClass(
+        id = id,
+        locationId = locationId,
+        name = name,
+        classType = classType,
+        coachId = coachId,
+        room = "Studio A",
+        startTime = startTime,
+        endTime = endTime,
+        capacity = capacity,
+        status = status,
+        createdAt = Instant.now(),
+    )
+
+    private fun buildBooking(
+        id: UUID = UUID.randomUUID(),
+        fitnessClass: FitnessClass,
+        userId: UUID = this.userId,
+        status: BookingStatus = BookingStatus.CONFIRMED,
+    ) = Booking(
+        id = id,
+        userId = userId,
+        fitnessClass = fitnessClass,
+        status = status,
+        bookedAt = Instant.now(),
+    )
+
+    // --- Public API Tests ---
+
+    @Test
+    fun `findClassById returns summary when class exists`() {
+        val id = UUID.randomUUID()
+        val fc = buildFitnessClass(id = id)
+        every { fitnessClassRepository.findById(id) } returns Optional.of(fc)
+
+        val result = service.findClassById(id)
+
+        assertTrue(result is Result.Success)
+        val summary = (result as Result.Success).value
+        assertEquals(id, summary.id)
+        assertEquals("Morning Yoga", summary.name)
+    }
+
+    @Test
+    fun `findClassById returns failure when class does not exist`() {
+        val id = UUID.randomUUID()
+        every { fitnessClassRepository.findById(id) } returns Optional.empty()
+
+        val result = service.findClassById(id)
+
+        assertTrue(result is Result.Failure)
+        val error = (result as Result.Failure).error
+        assertTrue(error is NotFoundError)
+    }
+
+    @Test
+    fun `findUpcomingClassesByLocationId delegates to repository`() {
+        val fc = buildFitnessClass()
+        every {
+            fitnessClassRepository.findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, any())
+        } returns listOf(fc)
+
+        val results = service.findUpcomingClassesByLocationId(locationId)
+
+        assertEquals(1, results.size)
+        assertEquals("Morning Yoga", results[0].name)
+    }
+
+    @Test
+    fun `getClassDetail returns detail when class exists`() {
+        val id = UUID.randomUUID()
+        val fc = buildFitnessClass(id = id)
+        every { fitnessClassRepository.findById(id) } returns Optional.of(fc)
+
+        val result = service.getClassDetail(id)
+
+        assertTrue(result is Result.Success)
+        val detail = (result as Result.Success).value
+        assertEquals(id, detail.id)
+        assertEquals("Morning Yoga", detail.name)
+    }
+
+    @Test
+    fun `getClassDetail returns failure when class does not exist`() {
+        val id = UUID.randomUUID()
+        every { fitnessClassRepository.findById(id) } returns Optional.empty()
+
+        val result = service.getClassDetail(id)
+
+        assertTrue(result is Result.Failure)
+        val error = (result as Result.Failure).error
+        assertTrue(error is NotFoundError)
+    }
+
+    @Test
+    fun `findClassesByLocationId returns detail list`() {
+        val fc = buildFitnessClass()
+        every {
+            fitnessClassRepository.findByLocationIdAndStartTimeAfterOrderByStartTimeAsc(locationId, any())
+        } returns listOf(fc)
+
+        val results = service.findClassesByLocationId(locationId)
+
+        assertEquals(1, results.size)
+        assertEquals("Morning Yoga", results[0].name)
+    }
+
+    @Test
+    fun `findClassesByCoachIdAndTimeRange delegates to repository`() {
+        val fc = buildFitnessClass()
+        val start = Instant.now()
+        val end = Instant.now().plus(7, ChronoUnit.DAYS)
+        every { fitnessClassRepository.findByCoachIdAndTimeRange(coachId, start, end) } returns listOf(fc)
+
+        val results = service.findClassesByCoachIdAndTimeRange(coachId, start, end)
+
+        assertEquals(1, results.size)
+        assertEquals("Morning Yoga", results[0].name)
+    }
+
+    @Test
+    fun `cancelClass sets status cancels bookings and publishes event`() {
+        val classId = UUID.randomUUID()
+        val fc = buildFitnessClass(id = classId)
+        val booking = buildBooking(fitnessClass = fc)
+
+        every { fitnessClassRepository.findById(classId) } returns Optional.of(fc)
+        every { bookingRepository.findByFitnessClassIdAndStatus(classId, BookingStatus.CONFIRMED) } returns listOf(booking)
+        every { bookingRepository.save(any()) } answers { firstArg() }
+        every { waitlistEntryRepository.findByFitnessClassIdOrderByPositionAsc(classId) } returns emptyList()
+        every { waitlistEntryRepository.deleteAll(any<List<WaitlistEntry>>()) } returns Unit
+        every { fitnessClassRepository.save(any()) } answers { firstArg() }
+
+        val result = service.cancelClass(classId)
+
+        assertEquals(FitnessClassStatus.CANCELLED, fc.status)
+        assertEquals(BookingStatus.CANCELLED, booking.status)
+        assertEquals(classId, result.classId)
+        assertEquals(1, result.affectedUserIds.size)
+
+        val eventSlot = slot<ClassCancelledEvent>()
+        verify { eventPublisher.publishEvent(capture(eventSlot)) }
+        assertEquals(classId, eventSlot.captured.classId)
+    }
+
+    @Test
+    fun `countBookingCancellationsBetween delegates to repository`() {
+        val start = Instant.now().minus(7, ChronoUnit.DAYS)
+        val end = Instant.now()
+        every { bookingRepository.countCancellationsBetween(start, end) } returns 5L
+
+        val result = service.countBookingCancellationsBetween(start, end, null)
+
+        assertEquals(5L, result)
+    }
+
+    @Test
+    fun `countBookingCancellationsBetween with locationId delegates to repository`() {
+        val start = Instant.now().minus(7, ChronoUnit.DAYS)
+        val end = Instant.now()
+        every { bookingRepository.countCancellationsBetweenAndLocationId(start, end, locationId) } returns 3L
+
+        val result = service.countBookingCancellationsBetween(start, end, locationId)
+
+        assertEquals(3L, result)
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/controller/ClassControllerWebMvcTest.kt
@@ -3,7 +3,7 @@ package com.nickdferrara.fitify.scheduling.internal.controller
 import com.nickdferrara.fitify.TestSecurityConfig
 import com.nickdferrara.fitify.scheduling.internal.dtos.response.ClassResponse
 import com.nickdferrara.fitify.scheduling.internal.model.BookClassResult
-import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
@@ -45,7 +45,7 @@ internal class ClassControllerWebMvcTest {
     lateinit var mockMvc: MockMvc
 
     @MockkBean
-    lateinit var schedulingService: SchedulingService
+    lateinit var schedulingCommandService: SchedulingCommandService
 
     private val classId = UUID.randomUUID()
     private val userId = UUID.randomUUID()
@@ -70,7 +70,7 @@ internal class ClassControllerWebMvcTest {
     @Test
     fun `GET classes returns paginated results`() {
         val response = buildClassResponse()
-        every { schedulingService.searchClasses(any(), any(), any(), any(), any(), any()) } returns
+        every { schedulingCommandService.searchClasses(any(), any(), any(), any(), any(), any()) } returns
             PageImpl(listOf(response))
 
         mockMvc.perform(
@@ -93,7 +93,7 @@ internal class ClassControllerWebMvcTest {
             status = "CONFIRMED",
             bookedAt = Instant.now(),
         )
-        every { schedulingService.bookClass(classId, any()) } returns BookClassResult.Booked(bookingResponse)
+        every { schedulingCommandService.bookClass(classId, any()) } returns BookClassResult.Booked(bookingResponse)
 
         mockMvc.perform(
             post("/api/v1/classes/$classId/book")
@@ -104,7 +104,7 @@ internal class ClassControllerWebMvcTest {
 
     @Test
     fun `DELETE booking returns NO_CONTENT`() {
-        every { schedulingService.cancelBooking(classId, any()) } returns Unit
+        every { schedulingCommandService.cancelBooking(classId, any()) } returns Unit
 
         mockMvc.perform(
             delete("/api/v1/classes/$classId/booking")
@@ -112,6 +112,6 @@ internal class ClassControllerWebMvcTest {
         )
             .andExpect(status().isNoContent)
 
-        verify { schedulingService.cancelBooking(classId, any()) }
+        verify { schedulingCommandService.cancelBooking(classId, any()) }
     }
 }

--- a/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListenerTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/scheduling/internal/listener/BusinessRuleEventListenerTest.kt
@@ -1,6 +1,6 @@
 package com.nickdferrara.fitify.scheduling.internal.listener
 
-import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingService
+import com.nickdferrara.fitify.scheduling.internal.service.interfaces.SchedulingCommandService
 import com.nickdferrara.fitify.shared.BusinessRuleUpdatedEvent
 import io.mockk.mockk
 import io.mockk.verify
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test
 
 class BusinessRuleEventListenerTest {
 
-    private val schedulingService = mockk<SchedulingService>(relaxed = true)
-    private val listener = BusinessRuleEventListener(schedulingService)
+    private val schedulingCommandService = mockk<SchedulingCommandService>(relaxed = true)
+    private val listener = BusinessRuleEventListener(schedulingCommandService)
 
     @Test
     fun `onBusinessRuleUpdated updates cancellation window hours`() {
@@ -22,7 +22,7 @@ class BusinessRuleEventListenerTest {
 
         listener.onBusinessRuleUpdated(event)
 
-        verify { schedulingService.cancellationWindowHours = 48L }
+        verify { schedulingCommandService.cancellationWindowHours = 48L }
     }
 
     @Test
@@ -36,7 +36,7 @@ class BusinessRuleEventListenerTest {
 
         listener.onBusinessRuleUpdated(event)
 
-        verify { schedulingService.maxWaitlistSize = 30 }
+        verify { schedulingCommandService.maxWaitlistSize = 30 }
     }
 
     @Test
@@ -50,6 +50,6 @@ class BusinessRuleEventListenerTest {
 
         listener.onBusinessRuleUpdated(event)
 
-        verify { schedulingService.maxBookingsPerDay = 5 }
+        verify { schedulingCommandService.maxBookingsPerDay = 5 }
     }
 }


### PR DESCRIPTION
## Summary
- Split the 515-line `SchedulingServiceImpl` god-class into two focused services following the established CQRS pattern from the subscription module
- `SchedulingQueryServiceImpl` implements `SchedulingApi` for cross-module reads and admin write commands (create/update/cancel class)
- `SchedulingCommandServiceImpl` implements the new `SchedulingCommandService` interface for internal CRUD, booking, waitlist, and search
- Moved `toSummary()` and `toDetail()` extension functions from private methods into `FitnessClassExtensions.kt`

## Test plan
- [x] Main source compilation (`compileKotlin`) passes
- [x] `SchedulingApi` interface unchanged — zero impact on admin module
- [x] Controllers and listener updated to inject `SchedulingCommandService`
- [x] Test files split into `SchedulingCommandServiceTest` (18 tests) and `SchedulingQueryServiceTest` (11 tests)
- [x] No remaining references to deleted `SchedulingService` or `SchedulingServiceImpl`