### PR TITLE
feat: add externalized CORS configuration

### DIFF
--- a/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsProperties.kt
+++ b/src/main/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsProperties.kt
@@ -1,0 +1,12 @@
+package com.nickdferrara.fitify.identity.internal.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fitify.cors")
+internal data class CorsProperties(
+    val allowedOrigins: List<String> = listOf("http://localhost:3000"),
+    val allowedMethods: List<String> = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"),
+    val allowedHeaders: List<String> = listOf("*"),
+    val allowCredentials: Boolean = true,
+    val maxAge: Long = 3600,
+)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,9 @@ spring:
       maximum-pool-size: 10
 
 fitify:
+  cors:
+    allowed-origins:
+      - http://localhost:3000
   encryption:
     key: dGVzdC1rZXktMzItYnl0ZXMtbG9uZy4u
   security:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,10 @@ spring:
       ddl-auto: none
     show-sql: false
 
+fitify:
+  cors:
+    allowed-origins: ${FITIFY_CORS_ALLOWED_ORIGINS}
+
 management:
   endpoint:
     health:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -4,6 +4,10 @@ spring:
       ddl-auto: validate
     show-sql: false
 
+fitify:
+  cors:
+    allowed-origins: ${FITIFY_CORS_ALLOWED_ORIGINS}
+
 logging:
   level:
     com.nickdferrara.fitify: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,12 @@ management:
         enabled: true
 
 fitify:
+  cors:
+    allowed-origins: ${FITIFY_CORS_ALLOWED_ORIGINS:http://localhost:3000}
+    allowed-methods: GET,POST,PUT,DELETE,PATCH,OPTIONS
+    allowed-headers: "*"
+    allow-credentials: true
+    max-age: 3600
   encryption:
     key: ${ENCRYPTION_KEY}
     run-migration: ${ENCRYPTION_RUN_MIGRATION:false}

--- a/src/test/kotlin/com/nickdferrara/fitify/TestSecurityConfig.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/TestSecurityConfig.kt
@@ -11,6 +11,7 @@ class TestSecurityConfig {
     @Bean
     fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
+            .cors { it.disable() }
             .csrf { it.disable() }
             .authorizeHttpRequests { it.anyRequest().permitAll() }
             .build()

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsConfigTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsConfigTest.kt
@@ -1,0 +1,102 @@
+package com.nickdferrara.fitify.identity.internal.config
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import org.springframework.web.filter.CorsFilter
+
+internal class CorsConfigTest {
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp() {
+        val corsProperties = CorsProperties(
+            allowedOrigins = listOf("http://localhost:3000", "http://example.com"),
+        )
+        val corsConfig = CorsConfiguration().apply {
+            allowedOrigins = corsProperties.allowedOrigins
+            allowedMethods = corsProperties.allowedMethods
+            allowedHeaders = corsProperties.allowedHeaders
+            allowCredentials = corsProperties.allowCredentials
+            maxAge = corsProperties.maxAge
+        }
+        val corsSource = UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", corsConfig)
+        }
+        val builder = MockMvcBuilders.standaloneSetup(TestController())
+        builder.addFilter<StandaloneMockMvcBuilder>(CorsFilter(corsSource))
+        mockMvc = builder.build()
+    }
+
+    @RestController
+    class TestController {
+        @GetMapping("/api/v1/auth/cors-test")
+        fun corsTest() = "ok"
+    }
+
+    @Test
+    fun `preflight from allowed origin returns CORS headers`() {
+        mockMvc.perform(
+            options("/api/v1/auth/cors-test")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name()),
+        )
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+    }
+
+    @Test
+    fun `preflight from disallowed origin is rejected`() {
+        mockMvc.perform(
+            options("/api/v1/auth/cors-test")
+                .header(HttpHeaders.ORIGIN, "http://evil.com")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET.name()),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+    }
+
+    @Test
+    fun `simple request from allowed origin includes CORS headers`() {
+        mockMvc.perform(
+            get("/api/v1/auth/cors-test")
+                .header(HttpHeaders.ORIGIN, "http://localhost:3000"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+    }
+
+    @Test
+    fun `simple request from disallowed origin is rejected`() {
+        mockMvc.perform(
+            get("/api/v1/auth/cors-test")
+                .header(HttpHeaders.ORIGIN, "http://evil.com"),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+    }
+
+    @Test
+    fun `multiple allowed origins work`() {
+        mockMvc.perform(
+            get("/api/v1/auth/cors-test")
+                .header(HttpHeaders.ORIGIN, "http://example.com"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://example.com"))
+    }
+}

--- a/src/test/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsPropertiesTest.kt
+++ b/src/test/kotlin/com/nickdferrara/fitify/identity/internal/config/CorsPropertiesTest.kt
@@ -1,0 +1,33 @@
+package com.nickdferrara.fitify.identity.internal.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class CorsPropertiesTest {
+
+    @Test
+    fun `defaults are correct`() {
+        val props = CorsProperties()
+        assertThat(props.allowedOrigins).containsExactly("http://localhost:3000")
+        assertThat(props.allowedMethods).containsExactly("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        assertThat(props.allowedHeaders).containsExactly("*")
+        assertThat(props.allowCredentials).isTrue()
+        assertThat(props.maxAge).isEqualTo(3600)
+    }
+
+    @Test
+    fun `custom values override defaults`() {
+        val props = CorsProperties(
+            allowedOrigins = listOf("https://app.example.com", "https://admin.example.com"),
+            allowedMethods = listOf("GET", "POST"),
+            allowedHeaders = listOf("Authorization", "Content-Type"),
+            allowCredentials = false,
+            maxAge = 7200,
+        )
+        assertThat(props.allowedOrigins).containsExactly("https://app.example.com", "https://admin.example.com")
+        assertThat(props.allowedMethods).containsExactly("GET", "POST")
+        assertThat(props.allowedHeaders).containsExactly("Authorization", "Content-Type")
+        assertThat(props.allowCredentials).isFalse()
+        assertThat(props.maxAge).isEqualTo(7200)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds profile-aware CORS support so frontends (e.g. `localhost:3000`) can call the API without being blocked by Spring Security's default cross-origin policy
- New `CorsProperties` data class with externalized config following existing `RateLimitProperties`/`KeycloakProperties` conventions
- `SecurityConfig` wires `CorsConfigurationSource` before the CSRF filter
- Per-profile YAML config: dev hardcodes `localhost:3000`, prod/staging require `FITIFY_CORS_ALLOWED_ORIGINS` env var (fail-fast if unset)

## Test plan
- [x] `CorsPropertiesTest` — verifies default values and custom overrides
- [x] `CorsConfigTest` — preflight allowed/disallowed origins, simple request allowed/disallowed origins, multi-origin support
- [x] `TestSecurityConfig` updated with `.cors { it.disable() }` so existing `@WebMvcTest` tests are unaffected
- [x] Manual: confirm preflight `OPTIONS` from `localhost:3000` returns `Access-Control-Allow-Origin`
- [x] Manual: confirm requests from unlisted origins are rejected with 403

Closes #57